### PR TITLE
Updated live/upcoming to show collabs containing favorite channels

### DIFF
--- a/src/views/Favorites.vue
+++ b/src/views/Favorites.vue
@@ -115,7 +115,10 @@ export default {
         },
         filteredLiveVideos() {
             return this.live.filter(live =>
-                this.favorites.includes(live.channel.id)
+                this.favorites.includes(live.channel.id) || 
+                live.channel_mentions.filter(channel =>
+                    this.favorites.includes(channel.id)
+                ).length > 0
             );
         },
         filteredByChannelType() {


### PR DESCRIPTION
Copied video filtering logic to live filtering to show live/upcoming streams for favorited channels that are part of a collab stream featured on a non-favorited channel.

Resolves issue #15