### PR TITLE
adds decode util and apply to components

### DIFF
--- a/src/components/VideoCard.vue
+++ b/src/components/VideoCard.vue
@@ -46,8 +46,8 @@
             </router-link>
             <!--  -->
             <v-list-item-content class="pa-0">
-                <v-list-item-title :class="['video-title', { 'video-watched': hasWatched }]" :title="video.title">
-                    {{ video.title }}
+                <v-list-item-title :class="['video-title', { 'video-watched': hasWatched }]" :title="title">
+                    {{ title }}
                 </v-list-item-title>
                 <v-list-item-subtitle v-if="includeChannel">
                     <router-link
@@ -86,7 +86,7 @@ import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import utc from "dayjs/plugin/utc";
 import advancedFormat from "dayjs/plugin/advancedFormat";
-import { formatCount, getVideoThumbnails } from "@/utils/functions";
+import { formatCount, getVideoThumbnails, decodeHTMLEntities } from "@/utils/functions";
 import { mdiCheck, mdiPlusBox } from "@mdi/js";
 
 dayjs.extend(relativeTime);
@@ -142,6 +142,9 @@ export default {
     },
     created() {},
     computed: {
+        title() {
+            return decodeHTMLEntities(this.video.title);
+        },
         formattedTime() {
             switch (this.video.status) {
                 case "upcoming":

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -73,3 +73,7 @@ export function debounce(func, wait, immediate) {
         if (callNow) func.apply(context, args);
     };
 }
+
+export function decodeHTMLEntities(str) {
+    return str.split("&amp;").join("&").split("&quot;").join('"');
+}

--- a/src/views/Watch.vue
+++ b/src/views/Watch.vue
@@ -14,7 +14,7 @@
                             </div>
                         </div>
                     </div>
-                    <v-card-title>{{ video.title }}</v-card-title>
+                    <v-card-title>{{ title }}</v-card-title>
                     <v-card-subtitle>
                         {{ formatTime(video.published_at) }}
                     </v-card-subtitle>
@@ -102,7 +102,7 @@ import ChannelImg from "@/components/ChannelImg";
 import LoadingOverlay from "@/components/LoadingOverlay";
 import VideoDescription from "@/components/VideoDescription";
 
-import { getVideoThumbnails } from "@/utils/functions";
+import { getVideoThumbnails, decodeHTMLEntities } from "@/utils/functions";
 
 export default {
     name: "Watch",
@@ -190,6 +190,9 @@ export default {
         },
     },
     computed: {
+        title() {
+            return decodeHTMLEntities(this.video.title);
+        },
         channel_chips() {
             const allMentions = new Map();
             this.channel_mentions


### PR DESCRIPTION
The decode function only works for two entities. Importing an entire library like "he" would be overkill, these two entities are the only ones that have been used thus far. 

Closes #RiceCakess/Holodex#17