### PR TITLE
Open external YT comment link in new tab, fix timestamp parsing, remove duplicate timestamps

### DIFF
--- a/src/components/video/Comment.vue
+++ b/src/components/video/Comment.vue
@@ -28,7 +28,12 @@
                 <span class="text-subtitle-2" style="color: #aaa">{{ expanded ? "Close" : "Read more" }}</span>
             </template>
         </truncated-text>
-        <a class="openOnYoutube" :href="`https://www.youtube.com/watch?v=${videoId}&lc=${comment.comment_key}`">
+        <a
+            class="openOnYoutube"
+            :href="`https://www.youtube.com/watch?v=${videoId}&lc=${comment.comment_key}`"
+            target="_blank"
+            rel="noopener noreferrer"
+        >
             <v-icon small>{{ mdiOpenInNew }}</v-icon>
         </a>
         <!-- comment body -->

--- a/src/components/video/Comment.vue
+++ b/src/components/video/Comment.vue
@@ -45,7 +45,7 @@ import { mdiOpenInNew } from "@mdi/js";
 import TruncatedText from "../common/TruncatedText";
 // import TruncatedText from '../common/TruncatedText.vue';
 
-const COMMENT_TIMESTAMP_REGEX = /(?:(\d+):)?(\d+):(\d+)/gm;
+const COMMENT_TIMESTAMP_REGEX = /(?:([0-5]?[0-9]):)?([0-5]?[0-9]):([0-5][0-9])/gm;
 
 export default {
     name: "Comment",

--- a/src/components/watch/WatchComments.vue
+++ b/src/components/watch/WatchComments.vue
@@ -82,20 +82,20 @@ export default {
                 return this.comments.sort((a, b) => b.times.length - a.times.length);
             }
             return this.comments
-                .filter((c) => c.times.find((t) => Math.abs(this.currentFilter - t) <= 10))
+                .filter((c) => Array.from(c.times).find((t) => Math.abs(this.currentFilter - t) <= 10))
                 .sort((a, b) => a.times.length - b.times.length);
         },
         groupedComments() {
             return this.comments.map((c) => {
                 // console.log(c);
                 let match = COMMENT_TIMESTAMP_REGEX.exec(c.message);
-                const times = [];
+                const times = new Set();
                 while (match != null) {
                     const hr = match[1];
                     const min = match[2];
                     const sec = match[3];
                     const time = Number(hr ?? 0) * 3600 + Number(min) * 60 + Number(sec);
-                    times.push(time);
+                    times.add(time);
                     match = COMMENT_TIMESTAMP_REGEX.exec(c.message);
                 }
                 c.times = times;

--- a/src/components/watch/WatchComments.vue
+++ b/src/components/watch/WatchComments.vue
@@ -31,7 +31,7 @@
 import Comment from "@/components/video/Comment";
 import { formatDuration } from "@/utils/time";
 
-const COMMENT_TIMESTAMP_REGEX = /(?:(\d+):)?(\d+):(\d+)/gm;
+const COMMENT_TIMESTAMP_REGEX = /(?:([0-5]?[0-9]):)?([0-5]?[0-9]):([0-5][0-9])/gm;
 
 export default {
     name: "WatchComments",

--- a/src/components/watch/WatchComments.vue
+++ b/src/components/watch/WatchComments.vue
@@ -82,7 +82,7 @@ export default {
                 return this.comments.sort((a, b) => b.times.length - a.times.length);
             }
             return this.comments
-                .filter((c) => Array.from(c.times).find((t) => Math.abs(this.currentFilter - t) <= 10))
+                .filter((c) => c.times.find((t) => Math.abs(this.currentFilter - t) <= 10))
                 .sort((a, b) => a.times.length - b.times.length);
         },
         groupedComments() {
@@ -98,7 +98,7 @@ export default {
                     times.add(time);
                     match = COMMENT_TIMESTAMP_REGEX.exec(c.message);
                 }
-                c.times = times;
+                c.times = Array.from(times);
                 return c;
             });
         },


### PR DESCRIPTION
Added the target and rel attributes for the external YouTube comment link so the link should open in a new tab by default.