### PR TITLE
Hacky support for youtube links in search bar

### DIFF
--- a/src/components/common/SearchBar.vue
+++ b/src/components/common/SearchBar.vue
@@ -200,6 +200,15 @@ export default {
                 return;
             }
 
+            if (this.query.length === 1 && this.query[0].type === "title & desc") {
+                // eslint-disable-next-line no-useless-escape
+                const url = this.query[0].value.match(/(?:youtube\.com\/\S*(?:(?:\/e(?:mbed))?\/|watch\?(?:\S*?&?v\=))|youtu\.be\/)([a-zA-Z0-9_-]{6,11})/);
+                if (url) {
+                    this.$router.push(`/watch/${url[1]}`);
+                    return;
+                }
+            }
+
             this.$router.push({
                 path: "/search",
                 query: { q: await json2csvAsync(this.query) },

--- a/src/utils/backend-api.js
+++ b/src/utils/backend-api.js
@@ -53,6 +53,12 @@ export default {
         return axiosInstance.get(`/clips?${q}`);
     },
     searchAutocomplete(query) {
+        // eslint-disable-next-line max-len, no-useless-escape
+        const q = query.match(/(?:(?:http|https):\/\/|)(?:www\.|)youtube\.com\/(channel|user)\/([a-zA-Z0-9\-_]{1,})/);
+
+        if (q)
+            return axiosInstance.get(`/search/autocomplete?q=${q[2]}`);
+
         return axiosInstance.get(`/search/autocomplete?q=${query}`);
     },
     searchVideo(queryObject) {


### PR DESCRIPTION
I tried to make Youtube URLs work in the search bar (as Issue #42 suggested). It's probably a hacky way of doing it, as i don't know much about Vue.JS, but it works.

If you paste a channel URL, it will work just like typing the name of the channel, if you paste a video URL (full or short) and select "title or desc" it will redirect to the video page in Holodex. Maybe creating a new search category or something would be better, but i have no idea how Vue.js works. Also not sure if using Regex is a good idea in a search bar.