### PR TITLE
Less hacky support for youtube links in search bar

### DIFF
--- a/src/components/common/SearchBar.vue
+++ b/src/components/common/SearchBar.vue
@@ -200,6 +200,15 @@ export default {
                 return;
             }
 
+            if (this.query.length === 1 && this.query[0].type === "title & desc") {
+                // eslint-disable-next-line no-useless-escape
+                const url = this.query[0].value.match(/(?:youtube\.com\/\S*(?:(?:\/e(?:mbed))?\/|watch\?(?:\S*?&?v\=))|youtu\.be\/)([a-zA-Z0-9_-]{6,11})/);
+                if (url) {
+                    this.$router.push(`/watch/${url[1]}`);
+                    return;
+                }
+            }
+
             this.$router.push({
                 path: "/search",
                 query: { q: await json2csvAsync(this.query) },

--- a/src/components/common/SearchBar.vue
+++ b/src/components/common/SearchBar.vue
@@ -39,6 +39,7 @@
                 <v-list-item class="ma-n1 py-0 pl-3 pr-1">
                     <div class="selected-card-type px-1 py-0 ma-0 rounded text--disabled caption">
                         <v-icon x-small v-if="selection.item.type === 'channel'">{{ icons.mdiYoutube }}</v-icon>
+                        <v-icon x-small v-if="selection.item.type === 'video url'">{{ icons.mdiYoutube }}</v-icon>
                         <v-icon x-small v-if="selection.item.type === 'topic'">{{ icons.mdiAnimationPlay }}</v-icon>
                         <v-icon x-small v-if="selection.item.type === 'org'">{{ mdiAccountMultiple }}</v-icon>
                         <v-icon x-small v-if="selection.item.type === 'title & desc'">{{ mdiTextSearch }}</v-icon>
@@ -68,6 +69,7 @@
                     <v-list-item-subtitle class="text--primary">
                         {{ i18nItem(dropdownItem.item.type) }}
                         <v-icon small v-if="dropdownItem.item.type === 'channel'">{{ icons.mdiYoutube }}</v-icon>
+                        <v-icon small v-if="dropdownItem.item.type === 'video url'">{{ icons.mdiYoutube }}</v-icon>
                         <v-icon small v-if="dropdownItem.item.type === 'topic'">{{ icons.mdiAnimationPlay }}</v-icon>
                         <v-icon small v-if="dropdownItem.item.type === 'org'">{{ mdiAccountMultiple }}</v-icon>
                         <v-icon small v-if="dropdownItem.item.type === 'title & desc'">{{ mdiTextSearch }}</v-icon>
@@ -159,7 +161,7 @@ export default {
             this.fromApi = [];
             const entropy = encodeURIComponent(val).length;
             if (entropy <= 2) return;
-            const formatted = val.replace("#", "").toLowerCase();
+            const formatted = val.replace("#", "");
             this.getAutocomplete(formatted)
                 .then((res) => {
                     let textQueries = [];
@@ -200,13 +202,9 @@ export default {
                 return;
             }
 
-            if (this.query.length === 1 && this.query[0].type === "title & desc") {
-                // eslint-disable-next-line no-useless-escape
-                const url = this.query[0].value.match(/(?:youtube\.com\/\S*(?:(?:\/e(?:mbed))?\/|watch\?(?:\S*?&?v\=))|youtu\.be\/)([a-zA-Z0-9_-]{6,11})/);
-                if (url) {
-                    this.$router.push(`/watch/${url[1]}`);
-                    return;
-                }
+            if (this.query.length === 1 && this.query[0].type === "video url") {
+                this.$router.push(`/watch/${this.query[0].value}`);
+                return;
             }
 
             this.$router.push({
@@ -236,6 +234,8 @@ export default {
             switch (item) {
                 case "channel":
                     return this.$t("component.search.type.channel");
+                case "video url":
+                    return this.$t("component.search.type.videourl");
                 case "topic":
                     return this.$t("component.search.type.topic");
                 case "org":

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -55,6 +55,7 @@ component:
       org: org
       titledesc: title & desc
       comments: comments
+      videourl: video url
   relatedVideo:
     clipsLabel: clips
     simulcastsLabel: simulcasts

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -48,6 +48,7 @@ component:
       org: "org"
       titledesc: "título y descripción"
       topic: "Tema"
+      videourl: "url de vídeo"
   video:
     comment:
       openOnYoutube: "Abrir comentario en"

--- a/src/locales/fr.yml
+++ b/src/locales/fr.yml
@@ -44,6 +44,7 @@ component:
       org: "org"
       titledesc: "titre et desc."
       topic: "sujet"
+      videourl: "url de la vidéo"
   video:
     comment:
       openOnYoutube: "ouvrir le commentaire sur"

--- a/src/locales/id.yml
+++ b/src/locales/id.yml
@@ -46,6 +46,7 @@ component:
       org: "org"
       titledesc: "judul & desk"
       topic: "topik"
+      videourl: "url video"
   video:
     comment:
       openOnYoutube: "Buka komentar di"

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -46,6 +46,7 @@ component:
       org: "組織"
       titledesc: "タイトル/概要"
       topic: "トピック"
+      videourl: "ビデオURL"
   video:
     comment:
       openOnYoutube: "コメントをYoutubeで開く"

--- a/src/locales/ms.yml
+++ b/src/locales/ms.yml
@@ -46,6 +46,7 @@ component:
       org: kumpulan
       titledesc: tajuk dan perihalan
       topic: topik
+      videourl: url video
   video:
     comment:
       openOnYoutube: buka ulasan di YouTube

--- a/src/locales/ru.yml
+++ b/src/locales/ru.yml
@@ -48,6 +48,7 @@ component:
       org: "агенство"
       titledesc: "название и описание"
       topic: "тема"
+      videourl: "ссылка на видео"
   video:
     comment:
       openOnYoutube: "открыть комментарий на"

--- a/src/locales/zhtw.yml
+++ b/src/locales/zhtw.yml
@@ -53,6 +53,7 @@ component:
       org: 團體
       titledesc: 標題與描述
       comments: 留言
+      videourl: 視頻地址
   relatedVideo:
     clipsLabel: 翻譯剪輯
     simulcastsLabel: 同時聯播

--- a/src/utils/backend-api.js
+++ b/src/utils/backend-api.js
@@ -3,6 +3,11 @@ import axiosRetry from "axios-retry";
 import { dayjs } from "@/utils/time";
 import querystring from "querystring";
 
+// eslint-disable-next-line max-len,no-useless-escape
+const CHANNEL_URL_REGEX = /(?:(?:http|https):\/\/|)(?:www\.|)youtube\.com\/(channel|user)\/([a-zA-Z0-9\-_]{1,})/;
+// eslint-disable-next-line max-len,no-useless-escape
+const VIDEO_URL_REGEX = /(?:youtube\.com\/\S*(?:(?:\/e(?:mbed))?\/|watch\?(?:\S*?&?v\=))|youtu\.be\/)([a-zA-Z0-9_-]{6,11})/;
+
 export const axiosInstance = axios.create({
     // baseURL: process.env.NODE_ENV === "development" ? "https://holodex.net/api/v2" : "/api/v2",
     baseURL: process.env.NODE_ENV === "development" ? "http://localhost:2434/v2" : "/api/v2",
@@ -53,11 +58,14 @@ export default {
         return axiosInstance.get(`/clips?${q}`);
     },
     searchAutocomplete(query) {
-        // eslint-disable-next-line max-len, no-useless-escape
-        const q = query.match(/(?:(?:http|https):\/\/|)(?:www\.|)youtube\.com\/(channel|user)\/([a-zA-Z0-9\-_]{1,})/);
+        const channelId = query.match(CHANNEL_URL_REGEX);
+        const videoId = query.match(VIDEO_URL_REGEX);
 
-        if (q)
-            return axiosInstance.get(`/search/autocomplete?q=${q[2]}`);
+        if (channelId) return axiosInstance.get(`/search/autocomplete?q=${channelId[2]}`);
+
+        if (videoId) {
+            return { data: [{ type: "video url", value: `${videoId[1]}` }] };
+        }
 
         return axiosInstance.get(`/search/autocomplete?q=${query}`);
     },

--- a/src/utils/backend-api.js
+++ b/src/utils/backend-api.js
@@ -53,6 +53,12 @@ export default {
         return axiosInstance.get(`/clips?${q}`);
     },
     searchAutocomplete(query) {
+        // eslint-disable-next-line max-len, no-useless-escape
+        const q = query.match(/(?:(?:http|https):\/\/|)(?:www\.|)youtube\.com\/(channel|user)\/([a-zA-Z0-9\-_]{1,})/);
+
+        if (q)
+            return axiosInstance.get(`/search/autocomplete?q=${q[2]}`);
+
         return axiosInstance.get(`/search/autocomplete?q=${query}`);
     },
     searchVideo(queryObject) {


### PR DESCRIPTION
I added a new type "video url" to use for the list items/selected queries. I moved the video URL detection to backend-api.js for consistency, maybe in a future version of the API, it can handle URLs for autocompletion searches. For now, an Object is returned with the data with the type "video url." Removed inline regex that @AshNiartis added in favor of a constant in backend-api.js

Only concern is that I removed the toLowercase() for the formatted string that gets used in the watch.search/getAutocomplete() function in SearchBar.vue. It doesn't appear to have an adverse effect on searching comments/titles/descriptions other than appearance, but it was necessary to have the behavior of autocomplete results followed by text query results in the list with the current implementation of watch.search. Otherwise, the video ID would be turned to all lowercase and would no longer work since the IDs are case-sensitive.

An alternative implementation is to check if the query is a URL first in watch.search and bypass getAutocomplete() if it's a URL, but then there would be no channel link autocompletion (channel name hints), though I wanted to avoid expanding watch.search too much.

For video URLs, the result is:
![chrome_2021-02-26_13-54-47](https://user-images.githubusercontent.com/8785414/109348530-42422700-783a-11eb-8f23-a3db3a5497e9.png)

For channel URLs, the result is, where autocomplete still detects Kanata's channel:
![chrome_2021-02-26_13-55-56](https://user-images.githubusercontent.com/8785414/109348596-5b4ad800-783a-11eb-9196-620bcb943e4b.png)
