### PR TITLE
Fix past dates not being localized

### DIFF
--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -53,7 +53,7 @@ export function formatDistance(time, lang = "en", $t) {
         ]);
         return diff;
     }
-    diff = $t("time.distance_past_date", [timeObj.fromNow(), timeObj.format("LT")]);
+    diff = $t("time.distance_past_date", [localizedDayjs(time, lang).fromNow()]);
     return diff;
 }
 


### PR DESCRIPTION
This partially addresses #43, specifically this part:
> My additional observation is that the datetime format is not localized based on UI language setting.

Tested this with every available locale, past video dates are now localized properly. 