### PR TITLE
Fix leading zeros in music editor itunes search

### DIFF
--- a/src/components/media/SongSearch.vue
+++ b/src/components/media/SongSearch.vue
@@ -30,9 +30,7 @@
 
                 <v-list-item-content class="py-1 pt-1">
                     <v-list-item-subtitle class="text--primary">
-                        🎵 {{ x.item.trackName }} [{{ Math.floor(x.item.trackTimeMillis / 1000 / 60) }}:{{
-                            Math.round(x.item.trackTimeMillis / 1000) % 60
-                        }}]
+                        🎵 {{ x.item.trackName }} [{{ formatDuration(x.item.trackTimeMillis) }}]
                     </v-list-item-subtitle>
                     <v-list-item-subtitle class="text--caption">
                         🎤 {{ x.item.artistName }} / {{ x.item.collectionName }} / {{ x.item.releaseDate.slice(0, 7) }}
@@ -50,9 +48,7 @@
 
                 <v-list-item-content class="py-1 pt-1">
                     <v-list-item-subtitle class="text--primary">
-                        🎵 {{ x.item.trackName }} [{{ Math.floor(x.item.trackTimeMillis / 1000 / 60) }}:{{
-                            Math.round(x.item.trackTimeMillis / 1000) % 60
-                        }}]
+                        🎵 {{ x.item.trackName }} [{{ formatDuration(x.item.trackTimeMillis, true) }}]
                     </v-list-item-subtitle>
                     <v-list-item-subtitle class="text--caption">
                         🎤 {{ x.item.artistName }} / {{ x.item.collectionName }} / {{ x.item.releaseDate.slice(0, 7) }}

--- a/src/components/media/SongSearch.vue
+++ b/src/components/media/SongSearch.vue
@@ -48,7 +48,7 @@
 
                 <v-list-item-content class="py-1 pt-1">
                     <v-list-item-subtitle class="text--primary">
-                        🎵 {{ x.item.trackName }} [{{ formatDuration(x.item.trackTimeMillis, true) }}]
+                        🎵 {{ x.item.trackName }} [{{ formatDuration(x.item.trackTimeMillis) }}]
                     </v-list-item-subtitle>
                     <v-list-item-subtitle class="text--caption">
                         🎤 {{ x.item.artistName }} / {{ x.item.collectionName }} / {{ x.item.releaseDate.slice(0, 7) }}


### PR DESCRIPTION
Fixes https://github.com/RiceCakess/Holodex/projects/1#card-57850838.

Re-using `formatDuration` for the fix.