### PR TITLE
Move show/hide live TL to toolbar under video frame

### DIFF
--- a/src/components/watch/WatchLiveChat.vue
+++ b/src/components/watch/WatchLiveChat.vue
@@ -24,12 +24,6 @@
         </WatchLiveTranslations>
         <div class="embedded-chat">
             <iframe :src="liveChatUrl" frameborder="0" />
-            <div class="chat-overlay-btn d-flex align-center">
-                <a class="text-body-2" @click="toggleTL">
-                    {{ showTL ? $t("views.watch.chat.hideTLBtn") : $t("views.watch.chat.showTLBtn") }}
-                    {{ newTL > 0 ? `(${newTL}*)` : "" }}
-                </a>
-            </div>
         </div>
     </v-sheet>
 </template>
@@ -62,12 +56,17 @@ export default {
             type: Boolean,
             default: false,
         },
+        showTL: {
+            type: Boolean,
+            default: false,
+        },
+        showTLFirstTime: {
+            type: Boolean,
+            default: false,
+        },
     },
     data() {
         return {
-            showTL: false,
-            showTLFirstTime: false,
-            newTL: 0,
             stickTop: false,
         };
     },
@@ -80,23 +79,9 @@ export default {
         },
     },
     methods: {
-        toggleTL() {
-            // showTLFirstTime will initiate connection
-            // showTL toggle will show/hide without terminating connection
-            if (!this.showTLFirstTime) {
-                this.showTLFirstTime = true;
-                this.showTL = true;
-                return;
-            }
-            this.showTL = !this.showTL;
-            this.newTL = 0;
-        },
         handleVideoUpdate(update) {
             // bubble event to Watch view
             this.$emit("videoUpdate", update);
-        },
-        handleHistoryLength() {
-            if (!this.showTL) this.newTL += 1;
         },
     },
 };

--- a/src/components/watch/WatchLiveChat.vue
+++ b/src/components/watch/WatchLiveChat.vue
@@ -83,6 +83,9 @@ export default {
             // bubble event to Watch view
             this.$emit("videoUpdate", update);
         },
+        handleHistoryLength(length) {
+            this.$emit("historyLength", length);
+        },
     },
 };
 </script>

--- a/src/views/Watch.vue
+++ b/src/views/Watch.vue
@@ -232,7 +232,7 @@ export default {
 
             showTL: !this.$store.state.isMobile,
             showTLFirstTime: !this.$store.state.isMobile,
-            newTL: 10,
+            newTL: 0,
 
             showLiveChat: true,
 

--- a/src/views/Watch.vue
+++ b/src/views/Watch.vue
@@ -28,9 +28,24 @@
                     </WatchFrame>
                     <WatchToolBar :video="video" noBackButton>
                         <template v-slot:buttons>
-                            <v-btn icon lg @click="toggleTL" :color="showTL ? 'primary' : ''">
-                                <v-icon>{{ mdiTranslate }}</v-icon>
-                            </v-btn>
+                            <v-tooltip bottom v-if="!$store.state.isMobile">
+                                <template v-slot:activator="{ on, attrs }">
+                                    <v-btn
+                                        icon
+                                        lg
+                                        @click="toggleTL"
+                                        :color="showTL ? 'primary' : ''"
+                                        v-bind="attrs"
+                                        v-on="on"
+                                    >
+                                        <div class="notification-sticker" v-if="newTL > 0"></div>
+                                        <v-icon>{{ mdiTranslate }}</v-icon>
+                                    </v-btn>
+                                </template>
+                                <span>{{
+                                    showTL ? $t("views.watch.chat.hideTLBtn") : $t("views.watch.chat.showTLBtn")
+                                }}</span>
+                            </v-tooltip>
                             <v-btn icon lg @click="showLiveChat = !showLiveChat" v-if="hasLiveChat">
                                 <v-icon>{{ showLiveChat ? mdiMessageOff : mdiMessage }}</v-icon>
                             </v-btn>
@@ -91,6 +106,7 @@
                                 @videoUpdate="handleVideoUpdate"
                                 :showTL="showTL"
                                 :showTLFirstTime="showTLFirstTime"
+                                @historyLength="handleHistoryLength"
                             />
                             <WatchMugen @playNext="playNext" v-if="isMugen" />
                             <WatchSideBar :video="video" @timeJump="seekTo" />
@@ -128,6 +144,7 @@
                 <WatchToolBar :video="video">
                     <template v-slot:buttons>
                         <v-btn icon lg @click="toggleTL" :color="showTL ? 'primary' : ''">
+                            <div class="notification-sticker" v-if="newTL > 0"></div>
                             <v-icon>{{ mdiTranslate }}</v-icon>
                         </v-btn>
                         <v-btn icon lg @click="showLiveChat = !showLiveChat" v-if="hasLiveChat">
@@ -161,6 +178,7 @@
                 :fixedBottom="!landscape"
                 :showTL="showTL"
                 :showTLFirstTime="showTLFirstTime"
+                @historyLength="handleHistoryLength"
             />
         </div>
     </div>
@@ -212,8 +230,9 @@ export default {
             mdiTranslate,
             icons,
 
-            showTL: false,
-            showTLFirstTime: false,
+            showTL: !this.$store.state.isMobile,
+            showTLFirstTime: !this.$store.state.isMobile,
+            newTL: 10,
 
             showLiveChat: true,
 
@@ -278,6 +297,12 @@ export default {
                 return;
             }
             this.showTL = !this.showTL;
+            this.newTL = 0;
+        },
+        handleHistoryLength() {
+            if (!this.showTL) {
+                this.newTL += 1;
+            }
         },
     },
     computed: {
@@ -328,4 +353,14 @@ export default {
 };
 </script>
 
-<style></style>
+<style>
+div.notification-sticker {
+    position: absolute;
+    top: 1px;
+    right: 2px;
+    border-radius: 4px;
+    width: 8px;
+    height: 8px;
+    background-color: rgb(230, 33, 23);
+}
+</style>

--- a/src/views/Watch.vue
+++ b/src/views/Watch.vue
@@ -28,7 +28,7 @@
                     </WatchFrame>
                     <WatchToolBar :video="video" noBackButton>
                         <template v-slot:buttons>
-                            <v-tooltip bottom v-if="!$store.state.isMobile">
+                            <v-tooltip bottom v-if="hasLiveChat && !$store.state.isMobile">
                                 <template v-slot:activator="{ on, attrs }">
                                     <v-btn
                                         icon
@@ -143,7 +143,7 @@
                 </WatchFrame>
                 <WatchToolBar :video="video">
                     <template v-slot:buttons>
-                        <v-btn icon lg @click="toggleTL" :color="showTL ? 'primary' : ''">
+                        <v-btn icon lg @click="toggleTL" :color="showTL ? 'primary' : ''" v-if="hasLiveChat">
                             <div class="notification-sticker" v-if="newTL > 0"></div>
                             <v-icon>{{ mdiTranslate }}</v-icon>
                         </v-btn>

--- a/src/views/Watch.vue
+++ b/src/views/Watch.vue
@@ -28,6 +28,9 @@
                     </WatchFrame>
                     <WatchToolBar :video="video" noBackButton>
                         <template v-slot:buttons>
+                            <v-btn icon lg @click="toggleTL" :color="showTL ? 'primary' : ''">
+                                <v-icon>{{ mdiTranslate }}</v-icon>
+                            </v-btn>
                             <v-btn icon lg @click="showLiveChat = !showLiveChat" v-if="hasLiveChat">
                                 <v-icon>{{ showLiveChat ? mdiMessageOff : mdiMessage }}</v-icon>
                             </v-btn>
@@ -86,6 +89,8 @@
                                 :mugenId="isMugen && '4ANxvWIM3Bs'"
                                 :key="'ytchat' + isMugen ? '4ANxvWIM3Bs' : video.id"
                                 @videoUpdate="handleVideoUpdate"
+                                :showTL="showTL"
+                                :showTLFirstTime="showTLFirstTime"
                             />
                             <WatchMugen @playNext="playNext" v-if="isMugen" />
                             <WatchSideBar :video="video" @timeJump="seekTo" />
@@ -122,6 +127,9 @@
                 </WatchFrame>
                 <WatchToolBar :video="video">
                     <template v-slot:buttons>
+                        <v-btn icon lg @click="toggleTL" :color="showTL ? 'primary' : ''">
+                            <v-icon>{{ mdiTranslate }}</v-icon>
+                        </v-btn>
                         <v-btn icon lg @click="showLiveChat = !showLiveChat" v-if="hasLiveChat">
                             <v-icon>{{ showLiveChat ? mdiMessageOff : mdiMessage }}</v-icon>
                         </v-btn>
@@ -151,6 +159,8 @@
                 :key="'ytchat' + video.id"
                 :fixedRight="landscape"
                 :fixedBottom="!landscape"
+                :showTL="showTL"
+                :showTLFirstTime="showTLFirstTime"
             />
         </div>
     </div>
@@ -170,7 +180,7 @@ import WatchToolBar from "@/components/watch/WatchToolbar.vue";
 
 import { decodeHTMLEntities } from "@/utils/functions";
 import { mapState } from "vuex";
-import { mdiOpenInNew, mdiRectangleOutline, mdiMessage, mdiMessageOff, mdiFullscreen } from "@mdi/js";
+import { mdiOpenInNew, mdiRectangleOutline, mdiMessage, mdiMessageOff, mdiFullscreen, mdiTranslate } from "@mdi/js";
 import * as icons from "@/utils/icons";
 
 export default {
@@ -199,7 +209,11 @@ export default {
             mdiMessage,
             mdiMessageOff,
             mdiFullscreen,
+            mdiTranslate,
             icons,
+
+            showTL: false,
+            showTLFirstTime: false,
 
             showLiveChat: true,
 
@@ -254,6 +268,16 @@ export default {
                 document.exitFullscreen();
                 this.fullScreen = false;
             }
+        },
+        toggleTL() {
+            // showTLFirstTime will initiate connection
+            // showTL toggle will show/hide without terminating connection
+            if (!this.showTLFirstTime) {
+                this.showTLFirstTime = true;
+                this.showTL = true;
+                return;
+            }
+            this.showTL = !this.showTL;
         },
     },
     computed: {


### PR DESCRIPTION
Some users were reporting issues with the `Show TLs`/`Hide TLs` button overlapping over various things injected into the YT chat via extensions (#89):
![image](https://user-images.githubusercontent.com/1665677/113001989-a88bd380-9171-11eb-80b0-1e97384c4d80.png)


This is a follow-up to #107, which tried to fix this by moving the button to the left side. This unfortunately led to overlapping with the `Top Chat` on some localisations:
![image](https://user-images.githubusercontent.com/1665677/113001943-9b6ee480-9171-11eb-8ddd-1e92227c2ee1.png)

This PR resolves the issue by removing the overlay entirely, changing the button to an icon, and moving it to the toolbar under the video frame.

Additionally, the live TL is now open by default when on desktop (as discussed on discord) and a "notification sticker" has been added on top of the show/hide live TL button. This sticker is displayed when the live TL chat is connected, but not being shown, and new live TLs have arrived since the live TL chat was last opened, hinting at the user to open it.

Here is how everything looks now:
Live TL is closed:
![image](https://user-images.githubusercontent.com/1665677/113000934-95c4cf00-9170-11eb-9bc9-7975d2aee8ba.png)
Live TL is open:
![image](https://user-images.githubusercontent.com/1665677/113039483-003d3580-9198-11eb-909a-cf1c0cc59d71.png)
Live TL is closed, and has new messages:
![image](https://user-images.githubusercontent.com/1665677/113039693-3d092c80-9198-11eb-937f-269d8f921603.png)
Hovering over the button also displays the localized `Show TLs`/`Hide TLs` text as a tooltip:
![image](https://user-images.githubusercontent.com/1665677/113001667-53e85880-9171-11eb-803e-abb7caa8c9cb.png)
![image](https://user-images.githubusercontent.com/1665677/113001544-2f8c7c00-9171-11eb-8c5c-afa59e5ca9c8.png)