### PR TITLE
Reduced live chat bottom padding & hotfixed scrolling issue

### DIFF
--- a/src/components/watch/WatchLiveChat.vue
+++ b/src/components/watch/WatchLiveChat.vue
@@ -98,7 +98,6 @@ export default {
 .watch-live-chat.mobile-live-chat {
     margin-right: 0px; /*calc(env(safe-area-inset-right) - 15px)*/
     margin-right: calc(env(safe-area-inset-right) / 2);
-    padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 
 /* center pre loading text */
@@ -154,8 +153,10 @@ export default {
     z-index: 10;
     /* pre-iOS 11.2 */
     height: calc((100% - 36px - 100vw * 0.5625) - constant(safe-area-inset-top));
+    padding-bottom: calc(constant(safe-area-inset-bottom) / 1.75);
     /* iOS 11.2 and later */
     height: calc((100% - 36px - 100vw * 0.5625) - env(safe-area-inset-top, 0px));
+    padding-bottom: calc(env(safe-area-inset-bottom) / 1.75);
 }
 
 .watch-live-chat.fixed-bottom > .embedded-chat {

--- a/src/views/Channel.vue
+++ b/src/views/Channel.vue
@@ -133,6 +133,7 @@ export default {
     },
     methods: {
         init() {
+            window.scrollTo(0, 0);
             this.$store.commit("channel/resetState");
             this.$store.commit("channel/resetVideos");
             this.$store.commit("channel/setId", this.$route.params.id);

--- a/src/views/Watch.vue
+++ b/src/views/Watch.vue
@@ -247,6 +247,7 @@ export default {
     },
     methods: {
         init() {
+            window.scrollTo(0, 0);
             this.startTime = 0;
             if (this.isMugen) {
                 this.initMugen();


### PR DESCRIPTION
1. Reduced live chat panel's bottom padding on portrait and removed bottom padding on landscape for a more aesthetically pleasing look
![](https://user-images.githubusercontent.com/28037970/113108765-ec491080-9237-11eb-91f9-6e19be2a492e.png)
![](https://user-images.githubusercontent.com/28037970/113108778-ee12d400-9237-11eb-83fa-7402deecfd0f.png)

2. hotfixed a scrolling issue related to notched iOS device by calling window.scrollTo() on some pages' init function

[gif](https://i.ibb.co/y6z7czj/Clean-Shot-2021-03-31-at-15-38-09.gif) showcasing the fix