### PR TITLE
Add toggle live TL back to multiview

### DIFF
--- a/src/components/multiview/TabbedLiveChat.vue
+++ b/src/components/multiview/TabbedLiveChat.vue
@@ -11,6 +11,7 @@
             style="width: 100%; height: calc(100% - 32px)"
             :key="activeVideos[currentTab].id"
             fluid
+            :controlTL="true"
         />
     </div>
 </template>

--- a/src/components/watch/WatchLiveChat.vue
+++ b/src/components/watch/WatchLiveChat.vue
@@ -4,15 +4,15 @@
         :class="{
             'fixed-bottom': fixedBottom,
             'fixed-right': fixedRight,
-            'show-tl-overlay': showTL,
+            'show-tl-overlay': shouldShowLiveTL,
             fluid: fluid,
         }"
     >
         <span class="loading-text">{{ $t("views.watch.chat.loading") }}</span>
         <WatchLiveTranslations
             :video="video"
-            v-if="showTLFirstTime"
-            v-show="showTL"
+            v-if="shouldConnectLiveTL"
+            v-show="shouldShowLiveTL"
             :class="{
                 'chat-overlay': fixedBottom || fixedRight,
                 'chat-overlay-stickbottom': $store.state.settings.liveTlStickBottom,
@@ -24,11 +24,18 @@
         </WatchLiveTranslations>
         <div class="embedded-chat">
             <iframe :src="liveChatUrl" frameborder="0" />
+            <div class="chat-overlay-btn d-flex align-center" v-if="controlTL">
+                <v-btn icon lg @click="toggleTL" :color="shouldShowLiveTL ? 'primary' : '#999999'">
+                    <div class="notification-sticker" v-if="hasNewTranslations"></div>
+                    <v-icon>{{ mdiTranslate }}</v-icon>
+                </v-btn>
+            </div>
         </div>
     </v-sheet>
 </template>
 
 <script>
+import { mdiTranslate } from "@mdi/js";
 import WatchLiveTranslations from "./WatchLiveTranslations.vue";
 
 export default {
@@ -64,10 +71,23 @@ export default {
             type: Boolean,
             default: false,
         },
+        controlTL: {
+            type: Boolean,
+            default: false,
+        },
     },
     data() {
         return {
+            mdiTranslate,
+
             stickTop: false,
+            // TODO: redesign live chat in multiview so that this jank can be removed
+            // duplicating the props here because TabbedLiveChat does not provide them.
+            tl: {
+                show: !this.$store.state.isMobile,
+                showFirstTime: !this.$store.state.isMobile,
+                new: 0,
+            },
         };
     },
     computed: {
@@ -77,6 +97,15 @@ export default {
                 window.location.hostname
             }&dark_theme=${this.$vuetify.theme.dark ? 1 : 0}`;
         },
+        shouldConnectLiveTL() {
+            return this.controlTL ? this.tl.showFirstTime : this.showTLFirstTime;
+        },
+        shouldShowLiveTL() {
+            return this.controlTL ? this.tl.show : this.showTL;
+        },
+        hasNewTranslations() {
+            return (this.controlTL ? this.tl.new : this.newTL) > 0;
+        },
     },
     methods: {
         handleVideoUpdate(update) {
@@ -84,7 +113,26 @@ export default {
             this.$emit("videoUpdate", update);
         },
         handleHistoryLength(length) {
-            this.$emit("historyLength", length);
+            if (this.controlTL) {
+                if (!this.tl.show) this.tl.new += 1;
+            } else {
+                // in this case, bubble the event
+                this.$emit("historyLength", length);
+            }
+        },
+        toggleTL() {
+            if (this.controlTL) {
+                console.log("toggle TL from live chat overlay");
+                // showTLFirstTime will initiate connection
+                // showTL toggle will show/hide without terminating connection
+                if (!this.tl.showFirstTime) {
+                    this.tl.showFirstTime = true;
+                    this.tl.show = true;
+                    return;
+                }
+                this.tl.show = !this.tl.show;
+                this.tl.new = 0;
+            }
         },
     },
 };
@@ -213,10 +261,20 @@ export default {
     top: initial;
 }
 .chat-overlay-btn {
-    /* right: 48px; */
-    left: 128px;
+    bottom: 4px;
+    left: 64px;
     height: 48px;
     position: absolute;
     z-index: 10;
+}
+
+div.notification-sticker {
+    position: absolute;
+    top: 1px;
+    right: 2px;
+    border-radius: 4px;
+    width: 8px;
+    height: 8px;
+    background-color: rgb(230, 33, 23);
 }
 </style>


### PR DESCRIPTION
#113 caused users to be unable to access the live TL in multiview. This PR adds the button from the toolbar to the live chat only in multiview mode (triggered by the `controlTL` property on the `WatchLiveChat` component)