### PR TITLE
Disable live TL + live TL toggle button in MugenClips

### DIFF
--- a/src/components/watch/WatchLiveChat.vue
+++ b/src/components/watch/WatchLiveChat.vue
@@ -4,14 +4,14 @@
         :class="{
             'fixed-bottom': fixedBottom,
             'fixed-right': fixedRight,
-            'show-tl-overlay': shouldShowLiveTL,
+            'show-tl-overlay': !isMugen && shouldShowLiveTL,
             fluid: fluid,
         }"
     >
         <span class="loading-text">{{ $t("views.watch.chat.loading") }}</span>
         <WatchLiveTranslations
             :video="video"
-            v-if="shouldConnectLiveTL"
+            v-if="!isMugen && shouldConnectLiveTL"
             v-show="shouldShowLiveTL"
             :class="{
                 'chat-overlay': fixedBottom || fixedRight,
@@ -72,6 +72,10 @@ export default {
             default: false,
         },
         controlTL: {
+            type: Boolean,
+            default: false,
+        },
+        isMugen: {
             type: Boolean,
             default: false,
         },

--- a/src/views/Watch.vue
+++ b/src/views/Watch.vue
@@ -28,7 +28,7 @@
                     </WatchFrame>
                     <WatchToolBar :video="video" noBackButton>
                         <template v-slot:buttons>
-                            <v-tooltip bottom v-if="hasLiveChat && !$store.state.isMobile">
+                            <v-tooltip bottom v-if="hasLiveTL && hasLiveChat && !$store.state.isMobile">
                                 <template v-slot:activator="{ on, attrs }">
                                     <v-btn
                                         icon
@@ -106,6 +106,7 @@
                                 @videoUpdate="handleVideoUpdate"
                                 :showTL="showTL"
                                 :showTLFirstTime="showTLFirstTime"
+                                :isMugen="isMugen"
                                 @historyLength="handleHistoryLength"
                             />
                             <WatchMugen @playNext="playNext" v-if="isMugen" />
@@ -143,7 +144,13 @@
                 </WatchFrame>
                 <WatchToolBar :video="video">
                     <template v-slot:buttons>
-                        <v-btn icon lg @click="toggleTL" :color="showTL ? 'primary' : ''" v-if="hasLiveChat">
+                        <v-btn
+                            icon
+                            lg
+                            @click="toggleTL"
+                            :color="showTL ? 'primary' : ''"
+                            v-if="hasLiveTL && hasLiveChat"
+                        >
                             <div class="notification-sticker" v-if="newTL > 0"></div>
                             <v-icon>{{ mdiTranslate }}</v-icon>
                         </v-btn>
@@ -179,6 +186,7 @@
                 :fixedBottom="!landscape"
                 :showTL="showTL"
                 :showTLFirstTime="showTLFirstTime"
+                :isMugen="isMugen"
                 @historyLength="handleHistoryLength"
             />
         </div>
@@ -231,6 +239,9 @@ export default {
             mdiTranslate,
             icons,
 
+            // by default:
+            //   mobile: not open
+            //   desktop: open except in mugen (where TL doesnt work)
             showTL: !this.$store.state.isMobile,
             showTLFirstTime: !this.$store.state.isMobile,
             newTL: 0,
@@ -320,6 +331,9 @@ export default {
         },
         hasLiveChat() {
             return this.isMugen || this.video.status === "live" || this.video.status === "upcoming";
+        },
+        hasLiveTL() {
+            return this.video.status === "live";
         },
         hasWatched() {
             return this.$store.getters["library/hasWatched"](this.video.id);


### PR DESCRIPTION
Live TL doesn't work in MugenClips (because they are never live videos), so there's no reason to ever display it. This hides both the live TL window and the live TL toggle button when in MugenClips.