### PR TITLE
Convert SFCs to use script lang TS

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -27,7 +27,7 @@
     </v-app>
 </template>
 
-<script>
+<script lang="ts">
 import MainNav from "@/components/nav/MainNav.vue";
 import pulltorefresh from "vue-awesome-pulltorefresh";
 import { dayjsLangs } from "./plugins/vuetify";
@@ -82,7 +82,7 @@ export default {
         // check for pwa updates
         document.addEventListener(
             "swUpdated",
-            (event) => {
+            (event: CustomEvent<any>) => {
                 this.registration = event.detail;
                 this.updateExists = true;
             },

--- a/src/components/channel/ChannelCard.vue
+++ b/src/components/channel/ChannelCard.vue
@@ -17,7 +17,7 @@
     </v-card>
 </template>
 
-<script>
+<script lang="ts">
 import ChannelImg from "./ChannelImg.vue";
 import ChannelInfo from "./ChannelInfo.vue";
 import ChannelSocials from "./ChannelSocials.vue";

--- a/src/components/channel/ChannelChip.vue
+++ b/src/components/channel/ChannelChip.vue
@@ -40,7 +40,7 @@
     </v-hover> -->
 </template>
 
-<script>
+<script lang="ts">
 import { resizeChannelPhoto } from "@/utils/functions";
 import ChannelSocials from "@/components/channel/ChannelSocials.vue";
 import ChannelImg from "./ChannelImg.vue";

--- a/src/components/channel/ChannelImg.vue
+++ b/src/components/channel/ChannelImg.vue
@@ -27,7 +27,7 @@
     <!-- :to="`/channel/${channel.id}`" -->
 </template>
 
-<script>
+<script lang="ts">
 import { resizeChannelPhoto } from "@/utils/functions";
 
 export default {

--- a/src/components/channel/ChannelInfo.vue
+++ b/src/components/channel/ChannelInfo.vue
@@ -28,12 +28,12 @@
     </v-list-item-content>
 </template>
 
-<script>
+<script lang="ts">
 import { formatCount } from "@/utils/functions";
 
 export default {
     components: {
-        ChannelSocials: () => import("./ChannelSocials"),
+        ChannelSocials: () => import("./ChannelSocials.vue"),
     },
     props: {
         channel: {

--- a/src/components/channel/ChannelList.vue
+++ b/src/components/channel/ChannelList.vue
@@ -106,7 +106,7 @@
     </v-list>
 </template>
 
-<script>
+<script lang="ts">
 import * as icons from "@/utils/icons";
 import ChannelImg from "./ChannelImg.vue";
 import ChannelInfo from "./ChannelInfo.vue";
@@ -118,7 +118,7 @@ export default {
         ChannelImg,
         ChannelInfo,
         ChannelSocials,
-        ChannelCard: () => import("./ChannelCard"),
+        ChannelCard: () => import("./ChannelCard.vue"),
     },
     data() {
         return {

--- a/src/components/channel/ChannelSocials.vue
+++ b/src/components/channel/ChannelSocials.vue
@@ -41,7 +41,7 @@
     </div>
 </template>
 
-<script>
+<script lang="ts">
 import * as icons from "@/utils/icons";
 // import { mapMutations } from "vuex";
 

--- a/src/components/common/ApiErrorMessage.vue
+++ b/src/components/common/ApiErrorMessage.vue
@@ -17,7 +17,7 @@
     </v-row>
 </template>
 
-<script>
+<script lang="ts">
 export default {
     name: "ApiErrorMessage",
 };

--- a/src/components/common/Carousel.vue
+++ b/src/components/common/Carousel.vue
@@ -23,7 +23,7 @@
     </div>
 </template>
 
-<script>
+<script lang="ts">
 export default {
     name: "Carousel",
     props: {

--- a/src/components/common/InfiniteLoad.vue
+++ b/src/components/common/InfiniteLoad.vue
@@ -5,7 +5,7 @@
     </div>
 </template>
 
-<script>
+<script lang="ts">
 import LoadingOverlay from "@/components/common/LoadingOverlay.vue";
 
 export default {

--- a/src/components/common/InstallPrompt.vue
+++ b/src/components/common/InstallPrompt.vue
@@ -46,7 +46,7 @@
     </div>
 </template>
 
-<script>
+<script lang="ts">
 import { mdiExportVariant } from "@mdi/js";
 
 export default {
@@ -104,7 +104,8 @@ export default {
             return ["iPhone", "iPad", "iPod"].includes(navigator.platform);
         },
         isStandAlone() {
-            return navigator.standalone || window.matchMedia("(display-mode: standalone)").matches;
+            type iOSNavigator = Navigator & { standalone: boolean };
+            return (navigator as iOSNavigator).standalone || window.matchMedia("(display-mode: standalone)").matches;
         },
     },
 };

--- a/src/components/common/LoadingOverlay.vue
+++ b/src/components/common/LoadingOverlay.vue
@@ -14,7 +14,7 @@
     </v-row>
 </template>
 
-<script>
+<script lang="ts">
 import ApiErrorMessage from "./ApiErrorMessage.vue";
 
 export default {

--- a/src/components/common/Logo.vue
+++ b/src/components/common/Logo.vue
@@ -22,7 +22,7 @@
     </svg>
 </template>
 
-<script>
+<script lang="ts">
 export default {
     name: "Logo",
 };

--- a/src/components/common/PaginateLoad.vue
+++ b/src/components/common/PaginateLoad.vue
@@ -17,7 +17,7 @@
     </div>
 </template>
 
-<script>
+<script lang="ts">
 import LoadingOverlay from "@/components/common/LoadingOverlay.vue";
 import isActive from "@/mixins/isActive";
 

--- a/src/components/common/ResponsiveMenu.vue
+++ b/src/components/common/ResponsiveMenu.vue
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 import { debounce } from "@/utils/functions";
 import VMenu from "vuetify/lib/components/VMenu/VMenu";
 

--- a/src/components/common/TruncatedText.vue
+++ b/src/components/common/TruncatedText.vue
@@ -18,7 +18,8 @@
     </div>
 </template>
 
-<script>
+<script lang="ts">
+// TODO(jprochazk): type declarations for this module
 import linkify from "vue-linkify";
 
 export default {

--- a/src/components/common/TwitterFeed.vue
+++ b/src/components/common/TwitterFeed.vue
@@ -11,16 +11,18 @@
         </a>
     </div>
 </template>
-<script>
+<script lang="ts">
 export default {
     mounted() {
-        if (!window.twttr) {
+        // TODO(jprochazk): declare this in globals.d.ts
+        const w = window as any;
+        if (!w.twttr) {
             const externalScript = document.createElement("script");
             externalScript.setAttribute("src", "https://platform.twitter.com/widgets.js");
             externalScript.setAttribute("async", "true");
             document.head.appendChild(externalScript);
         } else {
-            window.twttr.widgets.load();
+            w.twttr.widgets.load();
         }
     },
 };

--- a/src/components/media/SongFrame.vue
+++ b/src/components/media/SongFrame.vue
@@ -22,7 +22,7 @@
     </div>
 </template>
 
-<script>
+<script lang="ts">
 // import { MUSIC_PLAYER_STATE } from "@/utils/consts";
 
 export default {

--- a/src/components/media/SongItem.vue
+++ b/src/components/media/SongItem.vue
@@ -84,7 +84,7 @@
     </v-hover>
 </template>
 
-<script>
+<script lang="ts">
 import { formatDistance, secondsToHuman } from "@/utils/time";
 
 export default {

--- a/src/components/media/SongItemCard.vue
+++ b/src/components/media/SongItemCard.vue
@@ -76,7 +76,7 @@
     </v-hover>
 </template>
 
-<script>
+<script lang="ts">
 import ChannelImg from "@/components/channel/ChannelImg.vue";
 import { formatDistance } from "@/utils/time";
 

--- a/src/components/media/SongPlaylist.vue
+++ b/src/components/media/SongPlaylist.vue
@@ -13,7 +13,7 @@
     </v-list>
 </template>
 
-<script>
+<script lang="ts">
 import SongItem from "./SongItem.vue";
 
 export default {

--- a/src/components/media/SongSearch.vue
+++ b/src/components/media/SongSearch.vue
@@ -62,7 +62,7 @@
     </v-autocomplete>
 </template>
 
-<script>
+<script lang="ts">
 import {
     mdiLabel,
     mdiMagnifyPlusOutline,
@@ -73,8 +73,10 @@ import {
 } from "@mdi/js";
 import * as icons from "@/utils/icons";
 import { debounce } from "@/utils/functions";
+// TODO(jprochazk): type declarations for this module
 import jsonp from "jsonp-es6";
 import { formatDuration } from "@/utils/time";
+// TODO(jprochazk): type declarations for this module
 import { compareTwoStrings } from "string-similarity";
 
 export default {

--- a/src/components/media/SongTable.vue
+++ b/src/components/media/SongTable.vue
@@ -63,7 +63,7 @@
     </v-data-table>
 </template>
 
-<script>
+<script lang="ts">
 import { formatDistance, formatDuration, localizedDayjs } from "@/utils/time";
 import { mapState } from "vuex";
 

--- a/src/components/media/VideoEditSongs.vue
+++ b/src/components/media/VideoEditSongs.vue
@@ -243,7 +243,7 @@
     </div>
 </template>
 
-<script>
+<script lang="ts">
 import { mdiEarHearing, mdiRestore, mdiTimerOutline, mdiDebugStepOver } from "@mdi/js";
 import backendApi from "@/utils/backend-api";
 import { secondsToHuman } from "@/utils/time";
@@ -307,6 +307,7 @@ function getEmptySong(video) {
     };
 }
 
+// TODO(jprochazk): `Vue.extend` for type inference instead of the lazy way of `const self = this as any`
 export default {
     components: {
         SongSearch,
@@ -371,7 +372,7 @@ export default {
             get() {
                 return `${this.current.end - this.current.start}`;
             },
-            set(val) {
+            set(val: string) {
                 if (this.checkEndTime(val)) {
                     if (val.includes(":")) {
                         this.current.end = humanToSeconds(val);
@@ -394,18 +395,19 @@ export default {
     methods: {
         processSearch(item) {
             console.log(item);
-            this.current.song = item;
+            const self = this as any;
+            self.current.song = item;
             if (item) {
-                this.current.itunesid = item.trackId;
-                this.current.name = item.trackName;
-                this.current.original_artist = item.artistName;
-                this.currentEndTime = `+${Math.ceil(item.trackTimeMillis / 1000)}`;
-                this.current.amUrl = item.trackViewUrl;
-                this.current.art = item.artworkUrl100;
+                self.current.itunesid = item.trackId;
+                self.current.name = item.trackName;
+                self.current.original_artist = item.artistName;
+                self.currentEndTime = `+${Math.ceil(item.trackTimeMillis / 1000)}`;
+                self.current.amUrl = item.trackViewUrl;
+                self.current.art = item.artworkUrl100;
             } else {
-                this.current.itunesid = -1;
-                this.current.amUrl = null;
-                this.current.art = null;
+                self.current.itunesid = -1;
+                self.current.amUrl = null;
+                self.current.art = null;
             }
         },
         checkStartTime(val) {
@@ -416,27 +418,32 @@ export default {
         },
         secondsToHuman,
         async addSong() {
-            await this.saveCurrentSong();
+            const self = this as any;
+            await self.saveCurrentSong();
             // this.songList.push(this.current);
-            this.current = getEmptySong(this.video);
-            await this.refreshSongList();
+            self.current = getEmptySong(self.video);
+            await self.refreshSongList();
         },
         async refreshSongList() {
-            this.songList = (await backendApi.songListByVideo(this.video.channel.id, this.video.id, false)).data.sort(
+            const self = this as any;
+            self.songList = (await backendApi.songListByVideo(self.video.channel.id, self.video.id, false)).data.sort(
                 (a, b) => a.start - b.start,
             );
         },
         async saveCurrentSong() {
-            const res = await backendApi.tryCreateSong(this.current, this.$store.state.userdata.jwt);
+            const self = this as any;
+            const res = await backendApi.tryCreateSong(self.current, this.$store.state.userdata.jwt);
             console.log(res);
         },
         reset() {
-            this.current = getEmptySong(this.video);
-            this.refreshSongList();
+            const self = this as any;
+            self.current = getEmptySong(self.video);
+            self.refreshSongList();
         },
         async removeSong(song) {
+            const self = this as any;
             await backendApi.deleteSong(song, this.$store.state.userdata.jwt);
-            this.refreshSongList();
+            self.refreshSongList();
         },
         mountTwitter() {
             const externalScript = document.createElement("script");

--- a/src/components/multiview/Cell.vue
+++ b/src/components/multiview/Cell.vue
@@ -127,7 +127,7 @@
     </v-card>
 </template>
 
-<script>
+<script lang="ts">
 import { mdiMessage, mdiResizeBottomRight, mdiDelete } from "@mdi/js";
 import { getVideoThumbnails } from "@/utils/functions";
 import TabbedLiveChat from "@/components/multiview/TabbedLiveChat.vue";

--- a/src/components/multiview/LayoutPreview.vue
+++ b/src/components/multiview/LayoutPreview.vue
@@ -6,7 +6,7 @@
     </div>
 </template>
 
-<script>
+<script lang="ts">
 export default {
     name: "LayoutPreview",
     props: {

--- a/src/components/multiview/PresetSelector.vue
+++ b/src/components/multiview/PresetSelector.vue
@@ -33,7 +33,7 @@
     </v-card>
 </template>
 
-<script>
+<script lang="ts">
 import VideoCardList from "@/components/video/VideoCardList.vue";
 import LoadingOverlay from "@/components/common/LoadingOverlay.vue";
 import { decodeLayout } from "@/utils/mv-layout";

--- a/src/components/multiview/TabbedLiveChat.vue
+++ b/src/components/multiview/TabbedLiveChat.vue
@@ -16,7 +16,7 @@
     </div>
 </template>
 
-<script>
+<script lang="ts">
 import WatchLiveChat from "@/components/watch/WatchLiveChat.vue";
 
 export default {

--- a/src/components/multiview/VideoSelector.vue
+++ b/src/components/multiview/VideoSelector.vue
@@ -68,7 +68,7 @@
     </v-card>
 </template>
 
-<script>
+<script lang="ts">
 import api from "@/utils/backend-api";
 import VideoCardList from "@/components/video/VideoCardList.vue";
 import LoadingOverlay from "@/components/common/LoadingOverlay.vue";

--- a/src/components/nav/BottomNav.vue
+++ b/src/components/nav/BottomNav.vue
@@ -16,7 +16,7 @@
     </v-bottom-navigation>
 </template>
 
-<script>
+<script lang="ts">
 export default {
     name: "BottomNav",
     props: {
@@ -26,7 +26,7 @@ export default {
         },
         active: {
             type: Boolean,
-            require: false,
+            required: false,
             default: true,
         },
     },

--- a/src/components/nav/MainNav.vue
+++ b/src/components/nav/MainNav.vue
@@ -173,7 +173,7 @@
     </div>
 </template>
 
-<script>
+<script lang="ts">
 import * as icons from "@/utils/icons";
 import SearchBar from "@/components/common/SearchBar.vue";
 // import SearchBar from "@/components/nav/SearchBarSimple.vue";
@@ -304,7 +304,8 @@ export default {
         // getHeight() {
         //     console.log(this.$vuetify.breakpoint.width);
         //     // ^ very important, causes the function to link reactivity to width changes.
-        //     return Number.parseFloat(getComputedStyle(document.documentElement).getPropertyValue("--sat")) / 1.5 + 64;
+        //     return Number.parseFloat(
+        //         getComputedStyle(document.documentElement).getPropertyValue("--sat")) / 1.5 + 64;
         // },
         ...mapState(["firstVisit"]),
     },

--- a/src/components/nav/MusicBar2.vue
+++ b/src/components/nav/MusicBar2.vue
@@ -128,7 +128,7 @@
         ></song-frame>
     </v-bottom-sheet>
 </template>
-<script>
+<script lang="ts">
 import { MUSIC_PLAYBACK_MODE, MUSIC_PLAYER_STATE } from "@/utils/consts";
 import VueYouTubeEmbed from "vue-youtube-embed";
 import Vue from "vue";
@@ -202,7 +202,7 @@ export default {
         playlist(nw) {
             console.log("playlist: ", nw.length);
             if (nw.length === 0) this.$store.commit("music/closeBar");
-            if (this.isOpen === false > 0 && nw.length === 0) this.$store.commit("music/openBar");
+            if (this.isOpen === false && nw.length === 0) this.$store.commit("music/openBar");
         },
         currentSong(ns, os) {
             if (os != null && this.progress > 80) {

--- a/src/components/nav/NavDrawer.vue
+++ b/src/components/nav/NavDrawer.vue
@@ -75,7 +75,7 @@
     </v-navigation-drawer>
 </template>
 
-<script>
+<script lang="ts">
 import ChannelImg from "@/components/channel/ChannelImg.vue";
 import ChannelInfo from "@/components/channel/ChannelInfo.vue";
 import { langs } from "@/plugins/vuetify";

--- a/src/components/user/UserCard.vue
+++ b/src/components/user/UserCard.vue
@@ -135,7 +135,8 @@ export default {
             this.$store.dispatch("logout");
         },
         async tryUpdateUser() {
-            // TODO(jprochazk): this probably shouldn't be on window
+            // TODO(jprochazk): this doesn't have to be on window
+            // it'd be better to have it on `$store` or in `data`, but it being on window doesn't break anything.
             // @ts-ignore
             if (this.userdata && this.userdata.jwt && Date.now() - (window.lastUserCheck || 0) > 60000) {
                 // @ts-ignore

--- a/src/components/user/UserCard.vue
+++ b/src/components/user/UserCard.vue
@@ -91,7 +91,7 @@
     </v-card>
 </template>
 
-<script>
+<script lang="ts">
 import * as icons from "@/utils/icons";
 import backendApi from "@/utils/backend-api";
 
@@ -135,17 +135,20 @@ export default {
             this.$store.dispatch("logout");
         },
         async tryUpdateUser() {
+            // TODO(jprochazk): this probably shouldn't be on window
+            // @ts-ignore
             if (this.userdata && this.userdata.jwt && Date.now() - (window.lastUserCheck || 0) > 60000) {
+                // @ts-ignore
                 window.lastUserCheck = Date.now();
                 this.forceUserUpdate();
             }
         },
         async forceUserUpdate() {
             const check = await backendApi.loginIsValid(this.userdata.jwt);
-            if (check.data && check.data.id) {
-                this.$store.commit("setUser", { user: check.data, jwt: this.userdata.jwt });
-            } else {
+            if (check === false) {
                 this.$store.dispatch("logout");
+            } else if (check.data && check.data.id) {
+                this.$store.commit("setUser", { user: check.data, jwt: this.userdata.jwt });
             }
         },
     },

--- a/src/components/video/Comment.vue
+++ b/src/components/video/Comment.vue
@@ -17,7 +17,7 @@
     </v-list-item>
 </template>
 
-<script>
+<script lang="ts">
 import TruncatedText from "../common/TruncatedText.vue";
 // import TruncatedText from '../common/TruncatedText.vue';
 

--- a/src/components/video/Deprecated_VideoTopic.vue
+++ b/src/components/video/Deprecated_VideoTopic.vue
@@ -39,7 +39,7 @@
     </v-dialog>
 </template>
 
-<script>
+<script lang="ts">
 import * as icons from "@/utils/icons";
 import backendApi from "@/utils/backend-api";
 

--- a/src/components/video/VideoCard.vue
+++ b/src/components/video/VideoCard.vue
@@ -149,7 +149,7 @@
     </div>
 </template>
 
-<script>
+<script lang="ts">
 import { formatCount, getVideoThumbnails, decodeHTMLEntities } from "@/utils/functions";
 import { formatDuration, formatDistance, dayjs } from "@/utils/time";
 import * as icons from "@/utils/icons";
@@ -210,7 +210,7 @@ export default {
         hideThumbnail: {
             required: false,
             type: Boolean,
-            deafult: false,
+            default: false,
         },
         horizontal: {
             required: false,

--- a/src/components/video/VideoCardList.vue
+++ b/src/components/video/VideoCardList.vue
@@ -74,7 +74,7 @@
     </v-container>
 </template>
 
-<script>
+<script lang="ts">
 import VideoCard from "@/components/video/VideoCard.vue";
 import ApiErrorMessage from "@/components/common/ApiErrorMessage.vue";
 import { mdiChevronDown, mdiChevronUp } from "@mdi/js";
@@ -110,7 +110,7 @@ export default {
         hideThumbnail: {
             required: false,
             type: Boolean,
-            deafult: false,
+            default: false,
         },
         horizontal: {
             required: false,

--- a/src/components/video/VideoFavoritesList.vue
+++ b/src/components/video/VideoFavoritesList.vue
@@ -24,7 +24,7 @@
     </v-container>
 </template>
 
-<script>
+<script lang="ts">
 import VideoCardList from "@/components/video/VideoCardList.vue";
 
 export default {

--- a/src/components/watch/WatchComments.vue
+++ b/src/components/watch/WatchComments.vue
@@ -27,7 +27,7 @@
     </v-card>
 </template>
 
-<script>
+<script lang="ts">
 import Comment from "@/components/video/Comment.vue";
 import { formatDuration } from "@/utils/time";
 

--- a/src/components/watch/WatchFrame.vue
+++ b/src/components/watch/WatchFrame.vue
@@ -6,7 +6,7 @@
     </div>
 </template>
 
-<script>
+<script lang="ts">
 export default {
     name: "WatchFrame",
     components: {},

--- a/src/components/watch/WatchInfo.vue
+++ b/src/components/watch/WatchInfo.vue
@@ -69,7 +69,7 @@
     </v-card>
 </template>
 
-<script>
+<script lang="ts">
 import ChannelChip from "@/components/channel/ChannelChip.vue";
 import ChannelInfo from "@/components/channel/ChannelInfo.vue";
 import ChannelSocials from "@/components/channel/ChannelSocials.vue";

--- a/src/components/watch/WatchLiveChat.vue
+++ b/src/components/watch/WatchLiveChat.vue
@@ -34,7 +34,7 @@
     </v-sheet>
 </template>
 
-<script>
+<script lang="ts">
 import { mdiTranslate } from "@mdi/js";
 import WatchLiveTranslations from "./WatchLiveTranslations.vue";
 

--- a/src/components/watch/WatchLiveTranslations.vue
+++ b/src/components/watch/WatchLiveTranslations.vue
@@ -68,7 +68,7 @@
     </v-card>
 </template>
 
-<script>
+<script lang="ts">
 // eslint-disable-next-line import/no-unresolved
 import { Manager } from "socket.io-client";
 import api, { API_BASE_URL } from "@/utils/backend-api";
@@ -232,10 +232,11 @@ export default {
             });
         }, 300),
         tlChatDisconnect() {
-            if (this.socket) {
-                this.socket.disconnect(true);
-                this.socket = null;
-                this.manager = null;
+            const self = this as any;
+            if (self.socket) {
+                self.socket.disconnect(true);
+                self.socket = null;
+                self.manager = null;
             }
         },
         // tlChatReconnect() {
@@ -243,7 +244,7 @@ export default {
         //     this.tlChatConnect();
         // },
         utcToTimestamp(utc) {
-            return formatDuration(dayjs.utc(utc).subtract(dayjs(this.video.start_actual)));
+            return formatDuration(dayjs.utc(utc).subtract(Number(dayjs(this.video.start_actual))));
         },
     },
 };

--- a/src/components/watch/WatchMugen.vue
+++ b/src/components/watch/WatchMugen.vue
@@ -26,7 +26,7 @@
     </v-card>
 </template>
 
-<script>
+<script lang="ts">
 import api from "@/utils/backend-api";
 import VideoCardList from "@/components/video/VideoCardList.vue";
 import { localizedDayjs } from "@/utils/time";

--- a/src/components/watch/WatchSideBar.vue
+++ b/src/components/watch/WatchSideBar.vue
@@ -52,7 +52,7 @@
     </div>
 </template>
 
-<script>
+<script lang="ts">
 import VideoCardList from "@/components/video/VideoCardList.vue";
 import { mdiTimerOutline } from "@mdi/js";
 

--- a/src/components/watch/WatchToolbar.vue
+++ b/src/components/watch/WatchToolbar.vue
@@ -33,7 +33,7 @@
     </v-card>
 </template>
 
-<script>
+<script lang="ts">
 import { mdiOpenInNew, mdiArrowLeft } from "@mdi/js";
 
 export default {

--- a/src/external/vue-grid-layout/src/components/CustomDragElement.vue
+++ b/src/external/vue-grid-layout/src/components/CustomDragElement.vue
@@ -1,41 +1,41 @@
 <template>
     <span class="text">
-        {{text}}
-    <button>xxx</button>
-    <span class="vue-draggable-handle"></span>
+        {{ text }}
+        <button>xxx</button>
+        <span class="vue-draggable-handle"></span>
     </span>
 </template>
 <style>
-    .vue-draggable-handle {
-        position: absolute;
-        width: 20px;
-        height: 20px;
-        top: 0;
-        left: 0;
-        background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10'><circle cx='5' cy='5' r='5' fill='#999999'/></svg>") no-repeat;
-        background-position: bottom right;
-        padding: 0 8px 8px 0;
-        background-repeat: no-repeat;
-        background-origin: content-box;
-        box-sizing: border-box;
-        cursor: pointer;
-    }
+.vue-draggable-handle {
+    position: absolute;
+    width: 20px;
+    height: 20px;
+    top: 0;
+    left: 0;
+    background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10'><circle cx='5' cy='5' r='5' fill='#999999'/></svg>")
+        no-repeat;
+    background-position: bottom right;
+    padding: 0 8px 8px 0;
+    background-repeat: no-repeat;
+    background-origin: content-box;
+    box-sizing: border-box;
+    cursor: pointer;
+}
 </style>
-<script>
-    export default {
-        name: "CustomDragElement",
-        props: {
-            text : {
-                type: String,
-                default: "x",
-            },
+<script lang="ts">
+export default {
+    name: "CustomDragElement",
+    props: {
+        text: {
+            type: String,
+            default: "x",
         },
-        data: function() {
-            return {
-            }
-        },
-        mounted: function() {
-            console.log("### " + this.text + " ready!");
-        },
-    }
+    },
+    data: function () {
+        return {};
+    },
+    mounted: function () {
+        console.log("### " + this.text + " ready!");
+    },
+};
 </script>

--- a/src/external/vue-grid-layout/src/components/GridItem.vue
+++ b/src/external/vue-grid-layout/src/components/GridItem.vue
@@ -96,7 +96,7 @@
     cursor: none !important;
 }
 </style>
-<script>
+<script lang="ts">
 import { setTopLeft, setTransform } from "../helpers/utils";
 import { getControlPosition, createCoreData } from "../helpers/draggableUtils";
 import { getColsFromBreakpoint } from "../helpers/responsiveUtils";
@@ -465,12 +465,12 @@ export default {
         emitContainerResized() {
             // this.style has width and height with trailing 'px'. The
             // resized event is without them
-            let styleProps = {};
+            let styleProps = { width: "", height: "" };
             for (let prop of ["width", "height"]) {
                 let val = this.style[prop];
                 let matches = val.match(/^(\d+)px$/);
                 if (!matches) return;
-                styleProps[prop] = matches[1];
+                styleProps[prop as keyof typeof styleProps] = matches[1];
             }
             this.$emit("container-resized", this.i, this.h, this.w, styleProps.height, styleProps.width);
         },
@@ -482,7 +482,7 @@ export default {
             const { x, y } = position;
             // console.log(position);
             // console.log(event);
-            let newSize = { width: 0, height: 0 };
+            let newSize: { left?: number; top?: number; width: number; height: number } = { width: 0, height: 0 };
             let pos;
 
             // const newRect = {};
@@ -563,7 +563,6 @@ export default {
 
             this.lastW = x;
             this.lastH = y;
-
             const newXY = this.calcXY(newSize.top, newSize.left);
             // console.log(newSize);
 
@@ -790,6 +789,7 @@ export default {
                             width: maximum.width,
                         },
                     },
+                    modifiers: [],
                 };
 
                 if (this.preserveAspectRatio) {

--- a/src/external/vue-grid-layout/src/components/GridLayout.vue
+++ b/src/external/vue-grid-layout/src/components/GridLayout.vue
@@ -18,7 +18,7 @@
     transition: height 200ms ease;
 }
 </style>
-<script>
+<script lang="ts">
 import Vue from "vue";
 const elementResizeDetectorMaker = require("element-resize-detector");
 
@@ -315,7 +315,8 @@ export default {
         },
         dragEvent: function (eventName, id, x, y, h, w) {
             //console.log(eventName + " id=" + id + ", x=" + x + ", y=" + y);
-            let l = getLayoutItem(this.layout, id);
+            // TODO(jprochazk): trace this and give it a proper type
+            let l: any = getLayoutItem(this.layout, id);
             //GetLayoutItem sometimes returns null object
             if (l === undefined || l === null) {
                 l = { x: 0, y: 0 };
@@ -349,7 +350,8 @@ export default {
         },
         // eslint-disable-next-line no-unused-vars
         resizeEvent: function (eventName, id, x, y, h, w, edges) {
-            let l = getLayoutItem(this.layout, id);
+            // TODO(jprochazk): trace this and give it a proper type
+            let l: any = getLayoutItem(this.layout, id);
             // if(eventName === "resizeend") debugger;
             // edges
             //GetLayoutItem sometimes return null object

--- a/src/external/vue-grid-layout/src/components/TestElement.vue
+++ b/src/external/vue-grid-layout/src/components/TestElement.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <span class="text">
-            {{text}}
+            {{ text }}
         </span>
         <span class="remove" @click="$emit('removeItem', text)">x</span>
     </div>
@@ -14,21 +14,20 @@
     cursor: pointer;
 }
 </style>
-<script>
-    export default {
-        name: "TestElement",
-        props: {
-            text : {
-                type: String,
-                default: "x",
-            },
+<script lang="ts">
+export default {
+    name: "TestElement",
+    props: {
+        text: {
+            type: String,
+            default: "x",
         },
-        data: function() {
-            return {
-            }
-        },
-        mounted: function() {
-            console.log("### " + this.text + " ready!");
-        },
-    }
+    },
+    data: function () {
+        return {};
+    },
+    mounted: function () {
+        console.log("### " + this.text + " ready!");
+    },
+};
 </script>

--- a/src/external/vue-grid-layout/src/helpers/utils.ts
+++ b/src/external/vue-grid-layout/src/helpers/utils.ts
@@ -434,7 +434,7 @@ export function synchronizeLayoutWithChildren(initialLayout: Layout, children: A
  * @param  {String} [contextName] Context name for errors.
  * @throw  {Error}                Validation error.
  */
-export function validateLayout(layout: Layout, contextName: string): void {
+export function validateLayout(layout: Layout, contextName?: string): void {
     contextName = contextName || "Layout";
     const subProps = ["x", "y", "w", "h"];
     let keyArr = [];

--- a/src/utils/backend-api.ts
+++ b/src/utils/backend-api.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios, { AxiosResponse } from "axios";
 import axiosRetry from "axios-retry";
 import { dayjs } from "@/utils/time";
 import querystring from "querystring";
@@ -43,12 +43,12 @@ export default {
     },
     /**
      * Fetches a video
-     * @param {*} id the ID of the video
-     * @param {*} lang the acceptable subtitle languages
-     * @param {*} c whether to also provide comments, 1 to activate
+     * @param id the ID of the video
+     * @param lang the acceptable subtitle languages
+     * @param c whether to also provide comments, 1 to activate
      * @returns
      */
-    video(id, lang, c) {
+    video(id: string, lang?: string, c?: 1) {
         const q = querystring.stringify({ lang, c });
         return axiosInstance.get(`/videos/${id}?${q}`);
     },
@@ -98,7 +98,7 @@ export default {
             },
         );
     },
-    loginIsValid(jwt) {
+    loginIsValid(jwt): Promise<false | AxiosResponse<any>> {
         return axiosInstance
             .get("/user/check", {
                 headers: jwt ? { Authorization: `BEARER ${jwt}` } : {},

--- a/src/utils/mv-layout.js
+++ b/src/utils/mv-layout.js
@@ -40,7 +40,7 @@ export function encodeLayout({ layout, contents }) {
 /**
  * Decodes a string to layout array and contents
  * @param {string} encodedStr encoded string
- * @returns {{layout, contents}} layout and layout contents as array and object
+ * @returns {{layout, content}} layout and layout contents as array and object
  */
 export function decodeLayout(encodedStr) {
     const parsedLayout = [];

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -367,7 +367,7 @@
     </v-container>
 </template>
 
-<script>
+<script lang="ts">
 import { mdiExportVariant, mdiGithub } from "@mdi/js";
 import * as icons from "@/utils/icons";
 import TwitterFeed from "@/components/common/TwitterFeed.vue";

--- a/src/views/Channel.vue
+++ b/src/views/Channel.vue
@@ -28,7 +28,7 @@
     <LoadingOverlay :isLoading="isLoading" :showError="hasError" v-else />
 </template>
 
-<script>
+<script lang="ts">
 // import api from "@/utils/backend-api";
 import ChannelSocials from "@/components/channel/ChannelSocials.vue";
 import ChannelInfo from "@/components/channel/ChannelInfo.vue";

--- a/src/views/Channels.vue
+++ b/src/views/Channels.vue
@@ -62,7 +62,7 @@
     </v-container>
 </template>
 
-<script>
+<script lang="ts">
 import ChannelList from "@/components/channel/ChannelList.vue";
 // import InfiniteLoading from "vue-infinite-loading";
 import ApiErrorMessage from "@/components/common/ApiErrorMessage.vue";

--- a/src/views/EditVideo.vue
+++ b/src/views/EditVideo.vue
@@ -77,7 +77,7 @@
     <LoadingOverlay :isLoading="isLoading" :showError="hasError" v-else />
 </template>
 
-<script>
+<script lang="ts">
 import VueYouTubeEmbed from "vue-youtube-embed";
 import Vue from "vue";
 import LoadingOverlay from "@/components/common/LoadingOverlay.vue";

--- a/src/views/Favorites.vue
+++ b/src/views/Favorites.vue
@@ -65,7 +65,7 @@
     </v-container>
 </template>
 
-<script>
+<script lang="ts">
 import VideoCardList from "@/components/video/VideoCardList.vue";
 import LoadingOverlay from "@/components/common/LoadingOverlay.vue";
 // eslint-disable-next-line no-unused-vars

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -52,7 +52,7 @@
     </v-container>
 </template>
 
-<script>
+<script lang="ts">
 import VideoCardList from "@/components/video/VideoCardList.vue";
 import LoadingOverlay from "@/components/common/LoadingOverlay.vue";
 import { mapState } from "vuex";

--- a/src/views/Library.vue
+++ b/src/views/Library.vue
@@ -138,7 +138,7 @@
     </v-container>
 </template>
 
-<script>
+<script lang="ts">
 import VideoCardList from "@/components/video/VideoCardList.vue";
 import { mdiFileTable } from "@mdi/js";
 import { json2csvAsync } from "json-2-csv";
@@ -187,7 +187,7 @@ export default {
         },
         savedVideosList() {
             return Object.values(this.savedVideos)
-                .sort((a, b) => {
+                .sort((a: any, b: any) => {
                     const dateA = new Date(a.added_at).getTime();
                     const dateB = new Date(b.added_at).getTime();
                     return dateA > dateB ? 1 : -1;

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -75,7 +75,7 @@
     </v-container>
 </template>
 
-<script>
+<script lang="ts">
 import GAuth from "vue-google-oauth2";
 import open from "oauth-open";
 import api from "@/utils/backend-api";
@@ -162,10 +162,10 @@ export default {
         },
         async forceUserUpdate() {
             const check = await api.loginIsValid(this.userdata.jwt);
-            if (check.data && check.data.id) {
-                this.$store.commit("setUser", { user: check.data, jwt: this.userdata.jwt });
-            } else {
+            if (check === false) {
                 this.$store.dispatch("logout");
+            } else if (check.data && check.data.id) {
+                this.$store.commit("setUser", { user: check.data, jwt: this.userdata.jwt });
             }
         },
         async resetKey() {

--- a/src/views/MultiView.vue
+++ b/src/views/MultiView.vue
@@ -139,7 +139,7 @@
     </div>
 </template>
 
-<script>
+<script lang="ts">
 import VueYouTubeEmbed from "vue-youtube-embed";
 import Vue from "vue";
 import { GridLayout, GridItem } from "@/external/vue-grid-layout/src/components/index";

--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -13,7 +13,7 @@
     </v-container>
 </template>
 
-<script>
+<script lang="ts">
 export default {
     name: "NotFound",
 };

--- a/src/views/OrgMusic.vue
+++ b/src/views/OrgMusic.vue
@@ -112,7 +112,7 @@
     </v-container>
 </template>
 
-<script>
+<script lang="ts">
 import backendApi from "@/utils/backend-api";
 import SongItemCard from "@/components/media/SongItemCard.vue";
 import SongItem from "@/components/media/SongItem.vue";

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -41,7 +41,7 @@
     </v-container>
 </template>
 
-<script>
+<script lang="ts">
 import VideoCardList from "@/components/video/VideoCardList.vue";
 import api from "@/utils/backend-api";
 import { forwardTransformSearchToAPIQuery } from "@/utils/functions";
@@ -126,8 +126,8 @@ export default {
             const acceptable = this.filter.type === "all" ? ["stream", "clip"] : [this.filter.type];
             const sorter =
                 this.filter.sort === "oldest"
-                    ? (x, y) => new Date(x.available_at) - new Date(y.available_at)
-                    : (x, y) => new Date(y.available_at) - new Date(x.available_at);
+                    ? (x, y) => new Date(x.available_at).valueOf() - new Date(y.available_at).valueOf()
+                    : (x, y) => new Date(y.available_at).valueOf() - new Date(x.available_at).valueOf();
             return this.videos.filter((v) => acceptable.includes(v.type)).sort(sorter);
         },
     },

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -75,7 +75,7 @@
     </v-container>
 </template>
 
-<script>
+<script lang="ts">
 import { langs } from "@/plugins/vuetify";
 import { mdiTranslate, mdiFilter } from "@mdi/js";
 import { TL_LANGS } from "@/utils/consts";
@@ -151,7 +151,7 @@ export default {
             get() {
                 return this.$store.state.settings.clipLangs;
             },
-            set(val) {
+            set(val: any[]) {
                 // sort array to increase cache hit rate
                 this.$store.commit("settings/setClipLangs", val.sort());
             },

--- a/src/views/Watch.vue
+++ b/src/views/Watch.vue
@@ -194,7 +194,7 @@
     <LoadingOverlay :isLoading="isLoading" :showError="hasError" v-else />
 </template>
 
-<script>
+<script lang="ts">
 import VueYouTubeEmbed from "vue-youtube-embed";
 import Vue from "vue";
 import LoadingOverlay from "@/components/common/LoadingOverlay.vue";

--- a/src/views/channel_views/ChannelAbout.vue
+++ b/src/views/channel_views/ChannelAbout.vue
@@ -20,7 +20,7 @@
     </v-container>
 </template>
 
-<script>
+<script lang="ts">
 export default {
     name: "ChannelAbout",
     computed: {

--- a/src/views/channel_views/ChannelMusic.vue
+++ b/src/views/channel_views/ChannelMusic.vue
@@ -75,7 +75,7 @@
     </v-row>
 </template>
 
-<script>
+<script lang="ts">
 import backendApi from "@/utils/backend-api";
 import SongItemCard from "@/components/media/SongItemCard.vue";
 import SongItem from "@/components/media/SongItem.vue";

--- a/src/views/channel_views/ChannelStats.vue
+++ b/src/views/channel_views/ChannelStats.vue
@@ -63,7 +63,7 @@
 import api from "@/utils/backend-api";
 import { dayjs } from "@/utils/time";
 import { formatCount } from "@/utils/functions";
-// NOTE(jprochazk): this endpoint doesn't exist, but the component isn't used anywhere.
+// NOTE(jprochazk): this library is not in package.json, but the component isn't used anywhere.
 // import { CategoryScale, Chart, Line, LinearScale, LineController, Point, Tooltip } from "chart.js";
 
 // Chart.register(LineController, Line, Point, LinearScale, CategoryScale, Tooltip);

--- a/src/views/channel_views/ChannelStats.vue
+++ b/src/views/channel_views/ChannelStats.vue
@@ -59,13 +59,14 @@
     </v-container>
 </template>
 
-<script>
+<script lang="ts">
 import api from "@/utils/backend-api";
 import { dayjs } from "@/utils/time";
 import { formatCount } from "@/utils/functions";
-import { CategoryScale, Chart, Line, LinearScale, LineController, Point, Tooltip } from "chart.js";
+// NOTE(jprochazk): this endpoint doesn't exist, but the component isn't used anywhere.
+// import { CategoryScale, Chart, Line, LinearScale, LineController, Point, Tooltip } from "chart.js";
 
-Chart.register(LineController, Line, Point, LinearScale, CategoryScale, Tooltip);
+// Chart.register(LineController, Line, Point, LinearScale, CategoryScale, Tooltip);
 export default {
     name: "ChannelStats",
     data() {
@@ -78,6 +79,8 @@ export default {
         };
     },
     mounted() {
+        // NOTE(jprochazk): this endpoint doesn't exist, but the component isn't used anywhere.
+        // @ts-ignore
         api.channelStats(this.channel_id).then((res) => {
             this.allData = res.data.reverse();
             this.timeLabels = this.allData.map((row) => dayjs(row.day).format("M/D"));
@@ -103,8 +106,8 @@ export default {
             return dayjs(date).format("M/D");
         },
         formatCount,
-        loadChart(type) {
-            const ctx = document.getElementById(`${type}-chart`);
+        loadChart(/* type */) {
+            /* const ctx = document.getElementById(`${type}-chart`);
             const gridLineColor = this.darkMode ? "rgba(255,255,255,0.2)" : "rgba(0, 0, 0, 0.1)";
             const fontColor = this.darkMode ? "white" : "black";
             this.charts.push(
@@ -174,7 +177,7 @@ export default {
                         },
                     },
                 }),
-            );
+            ); */
         },
     },
 };

--- a/src/views/channel_views/ChannelVideos.vue
+++ b/src/views/channel_views/ChannelVideos.vue
@@ -22,7 +22,7 @@
     </div>
 </template>
 
-<script>
+<script lang="ts">
 import VideoCardList from "@/components/video/VideoCardList.vue";
 // import api from "@/utils/backend-api";
 import { mapState } from "vuex";


### PR DESCRIPTION
Doing this lead to the discovery of some typos and a few possible bugs, which turned out to be false alarms. 

This only a surface-level conversion, which means:
* It was necessary to use `any` or `ts-ignore` in some places, because the dependencies' types aren't available yet (for example, in places using `backend-api.ts`)
* When working with the components in the future, `any` and `ts-ignore` should still be used liberally to ease development