### PR TITLE
Live TL fixes

### DIFF
--- a/src/views/Watch.vue
+++ b/src/views/Watch.vue
@@ -28,7 +28,7 @@
                     </WatchFrame>
                     <WatchToolBar :video="video" noBackButton>
                         <template v-slot:buttons>
-                            <v-tooltip bottom v-if="hasLiveChat && !$store.state.isMobile">
+                            <v-tooltip bottom v-if="hasLiveTL && hasLiveChat && !$store.state.isMobile">
                                 <template v-slot:activator="{ on, attrs }">
                                     <v-btn
                                         icon
@@ -144,7 +144,13 @@
                 </WatchFrame>
                 <WatchToolBar :video="video">
                     <template v-slot:buttons>
-                        <v-btn icon lg @click="toggleTL" :color="showTL ? 'primary' : ''" v-if="hasLiveChat">
+                        <v-btn
+                            icon
+                            lg
+                            @click="toggleTL"
+                            :color="showTL ? 'primary' : ''"
+                            v-if="hasLiveTL && hasLiveChat"
+                        >
                             <div class="notification-sticker" v-if="newTL > 0"></div>
                             <v-icon>{{ mdiTranslate }}</v-icon>
                         </v-btn>
@@ -322,6 +328,9 @@ export default {
         },
         hasLiveChat() {
             return this.isMugen || this.video.status === "live" || this.video.status === "upcoming";
+        },
+        hasLiveTL() {
+            return this.video.status === "live" || this.video.status === "upcoming";
         },
         hasWatched() {
             return this.$store.getters["library/hasWatched"](this.video.id);

--- a/src/views/Watch.vue
+++ b/src/views/Watch.vue
@@ -228,7 +228,6 @@ export default {
         WatchMugen: () => import("@/components/watch/WatchMugen.vue"),
     },
     data() {
-        const vm = this as any;
         return {
             theatherMode: false,
             startTime: 0,
@@ -240,11 +239,6 @@ export default {
             mdiTranslate,
             icons,
 
-            // by default:
-            //   mobile: not open
-            //   desktop: open except in mugen (where TL doesnt work)
-            showTL: vm.status === "live" && !this.$store.state.isMobile,
-            showTLFirstTime: vm.status === "live" && !this.$store.state.isMobile,
             newTL: 0,
 
             showLiveChat: true,
@@ -355,6 +349,12 @@ export default {
         },
         comments() {
             return this.video.comments || [];
+        },
+        showTL() {
+            return this.video.status === "live" && !this.$store.state.isMobile;
+        },
+        showTLFirstTime() {
+            return this.video.status === "live" && !this.$store.state.isMobile;
         },
     },
     watch: {

--- a/src/views/Watch.vue
+++ b/src/views/Watch.vue
@@ -28,7 +28,7 @@
                     </WatchFrame>
                     <WatchToolBar :video="video" noBackButton>
                         <template v-slot:buttons>
-                            <v-tooltip bottom v-if="hasLiveTL && hasLiveChat && !$store.state.isMobile">
+                            <v-tooltip bottom v-if="hasLiveChat && !$store.state.isMobile">
                                 <template v-slot:activator="{ on, attrs }">
                                     <v-btn
                                         icon
@@ -144,13 +144,7 @@
                 </WatchFrame>
                 <WatchToolBar :video="video">
                     <template v-slot:buttons>
-                        <v-btn
-                            icon
-                            lg
-                            @click="toggleTL"
-                            :color="showTL ? 'primary' : ''"
-                            v-if="hasLiveTL && hasLiveChat"
-                        >
+                        <v-btn icon lg @click="toggleTL" :color="showTL ? 'primary' : ''" v-if="hasLiveChat">
                             <div class="notification-sticker" v-if="newTL > 0"></div>
                             <v-icon>{{ mdiTranslate }}</v-icon>
                         </v-btn>
@@ -239,6 +233,8 @@ export default {
             mdiTranslate,
             icons,
 
+            showTL: false,
+            showTLFirstTime: false,
             newTL: 0,
 
             showLiveChat: true,
@@ -327,9 +323,6 @@ export default {
         hasLiveChat() {
             return this.isMugen || this.video.status === "live" || this.video.status === "upcoming";
         },
-        hasLiveTL() {
-            return this.video.status === "live";
-        },
         hasWatched() {
             return this.$store.getters["library/hasWatched"](this.video.id);
         },
@@ -349,12 +342,6 @@ export default {
         },
         comments() {
             return this.video.comments || [];
-        },
-        showTL() {
-            return this.video.status === "live" && !this.$store.state.isMobile;
-        },
-        showTLFirstTime() {
-            return this.video.status === "live" && !this.$store.state.isMobile;
         },
     },
     watch: {

--- a/src/views/Watch.vue
+++ b/src/views/Watch.vue
@@ -228,6 +228,7 @@ export default {
         WatchMugen: () => import("@/components/watch/WatchMugen.vue"),
     },
     data() {
+        const vm = this as any;
         return {
             theatherMode: false,
             startTime: 0,
@@ -242,8 +243,8 @@ export default {
             // by default:
             //   mobile: not open
             //   desktop: open except in mugen (where TL doesnt work)
-            showTL: !this.$store.state.isMobile,
-            showTLFirstTime: !this.$store.state.isMobile,
+            showTL: vm.status === "live" && !this.$store.state.isMobile,
+            showTLFirstTime: vm.status === "live" && !this.$store.state.isMobile,
             newTL: 0,
 
             showLiveChat: true,


### PR DESCRIPTION
This ensures that videos which are upcoming won't have live TL showing (the live TL button won't show, either). It will appear when the video status changes to `live`.