### PR TITLE
Fixed bug when switching chat tab

### DIFF
--- a/src/components/multiview/TabbedLiveChat.vue
+++ b/src/components/multiview/TabbedLiveChat.vue
@@ -79,7 +79,10 @@ export default {
             set(val) {
                 const obj = this.$store.state.multiview.layoutContent[this.id];
                 obj.currentTab = val;
-                return this.$store.commit("multiview/setLayoutContentById", obj);
+                return this.$store.commit("multiview/setLayoutContentById", {
+                    id: this.id,
+                    content: obj,
+                });
             },
         },
         twitchChatLink() {


### PR DESCRIPTION
reappear:
1. open 2 videos in multiview
2. switch livechat tab
3. now you can't add more video or use preset layout

![image](https://user-images.githubusercontent.com/1288549/115990778-b2311b80-a5f7-11eb-988e-54f0b67e6e98.png)
