### PR TITLE
modify browserlist + fix build errors

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,3 +1,4 @@
 > 1%
-last 2 versions
+last 2 iOS major versions and > 0.5%
+last 2 safari versions and > 0.5%
 not dead

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,8 @@
 module.exports = {
     presets: ["@vue/cli-plugin-babel/preset", "@babel/preset-flow"],
-    plugins: ["@interactjs/dev-tools/babel-plugin-prod"],
+    plugins: [
+        "@interactjs/dev-tools/babel-plugin-prod",
+        "@babel/plugin-proposal-nullish-coalescing-operator",
+        "@babel/plugin-proposal-optional-chaining",
+    ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "holoclips",
       "version": "1.0.0",
       "workspaces": [
         "src/external/vue-grid-layout"
@@ -49,6 +50,8 @@
         "@babel/cli": "^7.12.10",
         "@babel/core": "^7.12.10",
         "@babel/eslint-parser": "^7.13.10",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.13.8",
+        "@babel/plugin-proposal-optional-chaining": "^7.13.12",
         "@babel/plugin-transform-flow-comments": "^7.12.13",
         "@babel/preset-env": "^7.13.12",
         "@babel/preset-flow": "^7.12.13",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,8 @@
     "@babel/cli": "^7.12.10",
     "@babel/core": "^7.12.10",
     "@babel/eslint-parser": "^7.13.10",
+    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.13.8",
+    "@babel/plugin-proposal-optional-chaining": "^7.13.12",
     "@babel/plugin-transform-flow-comments": "^7.12.13",
     "@babel/preset-env": "^7.13.12",
     "@babel/preset-flow": "^7.12.13",

--- a/src/external/vue-grid-layout/src/components/index.ts
+++ b/src/external/vue-grid-layout/src/components/index.ts
@@ -14,8 +14,8 @@ let installedMap: Map<Function, boolean> = new Map();
 let GlobalVue: VueConstructor = null;
 if (typeof window !== "undefined") {
     GlobalVue = window.Vue;
-} else if (typeof global !== "undefined") {
-    GlobalVue = global.Vue;
+} else if (typeof globalThis !== "undefined") {
+    GlobalVue = globalThis.Vue;
 }
 if (GlobalVue) {
     GlobalVue.use({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,8 +16,7 @@
     "baseUrl": ".",
     "outDir": "./dist",
     "types": [
-      "webpack-env",
-      "dotenv"
+      "webpack-env"
     ],
     "paths": {
       "@/*": [


### PR DESCRIPTION
This PR makes the build work with the new browser list by explicitly adding the required babel plugins. I'm not fully sure why this doesn't work by default, because those plugins should be part of preset-env, but alas, at least it works.

I also included two unrelated things: removed dotenv from types in tsconfig because it isnt actually installed, and removed the usage of `global`, because the website doesn't run on any node-like environment