### PR TITLE
Use page query when using hash in URL for tabs

### DIFF
--- a/src/components/common/PaginateLoad.vue
+++ b/src/components/common/PaginateLoad.vue
@@ -89,6 +89,7 @@ export default {
                         ...this.$route.query,
                         page: val,
                     },
+                    hash: `${this.$route.hash}`,
                 });
             },
         },

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -11,7 +11,7 @@
         <!-- Teleport tabs to nav extension slot -->
         <portal to="mainNavExt" :disabled="!$vuetify.breakpoint.xs || !isActive">
             <v-tabs
-                @change="$router.replace({ query: { page: null } })"
+                @change="$router.replace({ query: null })"
                 v-model="tab"
                 :centered="$vuetify.breakpoint.xs"
                 :class="$store.state.settings.darkMode ? 'secondary darken-1' : 'primary lighten-1'"

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -11,6 +11,7 @@
         <!-- Teleport tabs to nav extension slot -->
         <portal to="mainNavExt" :disabled="!$vuetify.breakpoint.xs || !isActive">
             <v-tabs
+                @change="$router.replace({ query: { page: null } })"
                 v-model="tab"
                 :centered="$vuetify.breakpoint.xs"
                 :class="$store.state.settings.darkMode ? 'secondary darken-1' : 'primary lighten-1'"
@@ -138,13 +139,28 @@ export default {
                 window.scrollTo(0, 0);
                 switch (this.tab) {
                     case 0:
-                        this.$router.replace("#vtuber");
+                        this.$router.replace({
+                            query: {
+                                ...this.$route.query,
+                            },
+                            hash: "vtuber",
+                        });
                         break;
                     case 1:
-                        this.$router.replace("#archive");
+                        this.$router.replace({
+                            query: {
+                                ...this.$route.query,
+                            },
+                            hash: "archive",
+                        });
                         break;
                     case 2:
-                        this.$router.replace("#clips");
+                        this.$router.replace({
+                            query: {
+                                ...this.$route.query,
+                            },
+                            hash: "clips",
+                        });
                         break;
                     default:
                         break;


### PR DESCRIPTION
The following changes were made in order to use the page query with hashes for tabs:

1. Preserve the current page query when switching tabs in tab() in Home.vue by not replacing it with only #vtuber/#archive/#clips in $router.replace()
2. Perserve the hash in PaginateLoad.vue when switching pages
3. When navigating through the Live/Upcoming, Archive, and Clips tabs, clear queries completely with on change event for v-tabs.