### PR TITLE
Fix tab swiping hash/page query, use hash/page query when Home/Favorite view is activated

### DIFF
--- a/src/views/Favorites.vue
+++ b/src/views/Favorites.vue
@@ -2,8 +2,14 @@
     <v-container
         fluid
         v-touch="{
-            right: () => (tab = Math.max(tab - 1, 0)),
-            left: () => (tab = Math.min(tab + 1, 2)),
+            right: () => {
+                tab = Math.max(tab - 1, 0);
+                changeTab(false);
+            },
+            left: () => {
+                tab = Math.min(tab + 1, 2);
+                changeTab(false);
+            },
         }"
         style="min-height: 100%"
         class="d-flex flex-column"
@@ -144,6 +150,9 @@ export default {
     },
     mounted() {
         this.init(true);
+    },
+    activated() {
+        this.changeTab(false);
     },
     watch: {
         favorites: {

--- a/src/views/Favorites.vue
+++ b/src/views/Favorites.vue
@@ -152,7 +152,7 @@ export default {
         this.init(true);
     },
     activated() {
-        this.changeTab(false);
+        this.changeTab(true);
     },
     watch: {
         favorites: {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -2,8 +2,14 @@
     <v-container
         fluid
         v-touch="{
-            right: () => (tab = Math.max(tab - 1, 0)),
-            left: () => (tab = Math.min(tab + 1, 2)),
+            right: () => {
+                tab = Math.max(tab - 1, 0);
+                changeTab(false);
+            },
+            left: () => {
+                tab = Math.min(tab + 1, 2);
+                changeTab(false);
+            },
         }"
         style="min-height: 100%"
         class="d-flex flex-column"
@@ -128,6 +134,9 @@ export default {
     },
     mounted() {
         this.init();
+    },
+    activated() {
+        this.changeTab(false);
     },
     watch: {
         // eslint-disable-next-line func-names

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -136,7 +136,7 @@ export default {
         this.init();
     },
     activated() {
-        this.changeTab(false);
+        this.changeTab(true);
     },
     watch: {
         // eslint-disable-next-line func-names


### PR DESCRIPTION
This PR fixes two bugs where the hash/page queries are incorrectly set:

**1.) When swiping between tabs with touch, if there is a page query already in the URL, it will be preserved when changing between the clips and archives tab. This means that someone on page 3 of the clips tab that switches to the archives tab will be brought to page 3 for archives.**

Expected behavior is that the page query should be gone when switching.

To reproduce on a **touch enabled device**:
1.) Turn off scroll mode.
2.) Go to home or favorites, switch to clips, and navigate to the next page. Your URL should look like this: `https://staging.holodex.net/home?page=2#clips`
3.) Swipe to go to the archives tab. Your URL will now show: `https://staging.holodex.net/home?page=2#archive`

To fix this, I added a call to `changeTab(false)` for the right and left callback in v-touch for the container to make sure the URL is updated correctly.

**2.) When navigating away from Home/Favorites (such as to the Settings view) after going to the archives or clips tab, and returning to Home or Favorites which will restore the last tab the user was on, the URL does not reflect the current tab using `#archive` or `#clips`. After that, when the user then navigates to the next page, the URL will append the page query but won't include the hash.**

Expected behavior is that when a user returns to Home/Favorite, `#archive` or `#clips` will be appended to the end of the URL when they are also brought back to the previous tab they were on.

To reproduce on any device:
1.) Turn off scroll mode.
2.) On Home or Favorite, switch tabs to clips. The URL will show `https://staging.holodex.net/home#clips`.
3.) Navigate away from Home/Favorite to Settings.
4.) Return to Home/Favorite. The last tab which was clips will be set but the URL now shows `https://staging.holodex.net/home`.
5.) Attempt to navigate to the next page. The URL will now show `https://staging.holodex.net/home?page=2` and still does not include the hash for the clips tab they are on.

To fix this, because the Home and Favorite views are kept alive, I used the lifecycle hook activated() to set the hash to the correct tab that was previously set. To ensure that people can still manually navigate through pages, `changeTab(true)` is used.

I'm not completely familiar with Vue.js or Vuetify so these fixes are based on what limited knowledge I have about the available APIs. If there are better proposals to fix this, feedback is appreciated.