### PR TITLE
Add recommended extensions of vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,9 +15,12 @@ pnpm-debug.log*
 
 # Editor directories and files
 .idea
-.vscode
 *.suo
 *.ntvs*
 *.njsproj
 *.sln
 *.sw?
+
+# vscode configurations (exclude extension declarations)
+.vscode/*
+!/.vscode/extensions.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,12 @@
+{
+	"recommendations": [
+        "antfu.i18n-ally",
+        "irongeek.vscode-env",
+        "jpruliere.env-autocomplete",
+        "lukas-tr.materialdesignicons-intellisense",
+        "octref.vetur",
+        "jcbuisson.vue",
+        "dbaeumer.vscode-eslint",
+        "intellsmi.comment-translate",
+	]
+}


### PR DESCRIPTION
The recommended vscode extensions are specified in the README file of the repository, but because the extensions.json file is not specified, there is a problem with accessibility in the first contribution.

To solve this problem, I ignored the files in the .vscode folder and excluded the extensions.json file that defines the extension.

Also, by specifying Suggested VSCode Extensions in the extensions.json file, the extension can be installed directly from the IDE.