### PR TITLE
Fix MultiView button in Watch for certain vtubers

### DIFF
--- a/src/components/watch/WatchToolbar.vue
+++ b/src/components/watch/WatchToolbar.vue
@@ -35,7 +35,7 @@
                     </v-list-item>
                     <v-list-item
                         :disabled="video.type === 'clip'"
-                        :to="`/multiview/AAUY${video.id}${video.channel.name}%2CUAEYchat`"
+                        :to="`/multiview/AAUY${video.id}${getChannelShortname(video.channel)}%2CUAEYchat`"
                     >
                         <v-icon left :color="video.type === 'clip' ? 'grey' : ''">
                             {{ icons.mdiViewDashboard }}
@@ -85,6 +85,12 @@ export default {
         };
     },
     methods: {
+        getChannelShortname(ch) {
+            return (
+                (ch.english_name && ch.english_name.split(/[/\s]/g).join("_")) ||
+                ch.name.split(/[/\s]/)[0].replace(",", "")
+            );
+        },
         toggleSaved() {
             this.hasSaved
                 ? this.$store.commit("library/removeSavedVideo", this.video.id)


### PR DESCRIPTION
MultiView button in the Watch view's toolbar doesn't work for VTubers such as Uruca and Tokimori Aoi due to not correctly handling their channel name.

To reproduce the bug:
1. Go to `https://holodex.net/watch/gevOIX-xyLM`
2. Click on vertical 3 dots/dropdown and click on MultiView button
3. User will be brought to a 404 content not found page trying to navigate to `https://holodex.net/multiview/AAUYgevOIX-xyLMUruca%20ch%20/%E3%81%86%E3%82%8B%E3%81%8B%2CUAEYchat`

Expected:
When using the same option from the video list in Uruca's channel, the user will navigate to `https://holodex.net/multiview/AAUYgevOIX-xyLMUruca%2CUAEYchat`

Fix:
Use same code from VideoCardMenu.vue to get the correct URL. A better fix might be to rewrite the list to work both for the video card and the watch toolbar.