### PR TITLE
Added drag and drop functionality between videos/streams and MultiView cells

### DIFF
--- a/src/components/multiview/Cell.vue
+++ b/src/components/multiview/Cell.vue
@@ -5,6 +5,8 @@
         :class="{
             'edit-mode': pausedMode,
         }"
+        v-on:drop="drop"
+        v-on:dragover="allowDrop"
     >
         <!-- When Cell has no content: show video picker -->
         <v-sheet style="height: 100%" class="d-flex flex-column pt-4" v-if="!cellContent">
@@ -286,6 +288,35 @@ export default {
         setLayoutFreeze(newMode = this.pausedMode) {
             if (newMode) this.$store.commit("multiview/unfreezeLayoutItem", this.item.i);
             else this.$store.commit("multiview/freezeLayoutItem", this.item.i);
+        },
+        allowDrop(ev) {
+            ev.preventDefault();
+        },
+        drop(ev) {
+            
+            ev.preventDefault();
+            const data:string = ev.dataTransfer.getData("text");
+            let videoid:string;
+            let videotype:string;
+            if (/(youtube.com\/watch\?v=|youtu.be\/|holodex.net\/watch\/).{11}$/.test(data)) {
+                videoid = data.slice(-11);
+            } else if (/twitch.tv\/*/.test(data)) {
+                videotype = "twitch";
+                // I AM NOT GOING TO USE THE WEIRD ARRAY DESTRUCTURING SYNTAX
+                // eslint-disable-next-line
+                videoid = data.split(/twitch.tv\//)[1];
+            }
+            else return;
+            this.$store.commit("multiview/setLayoutContentById", {
+                id: this.item.i,
+                content: {
+                    type: "video",
+                    content: {
+                        cellVideoType: videotype,
+                        id: videoid,
+                    },
+                },
+            });
         },
     },
 };

--- a/src/components/video/VideoCard.vue
+++ b/src/components/video/VideoCard.vue
@@ -10,6 +10,8 @@
         :target="redirectMode ? '_blank' : ''"
         :href="!redirectMode ? `/watch/${video.id}` : `https://youtu.be/${video.id}`"
         rel="noopener"
+        draggable="true"
+        v-on:dragstart="drag"
     >
         <!-- Video Image with Duration -->
         <v-img
@@ -336,6 +338,12 @@ export default {
             //     console.log("sdses");
             this.$store.commit("setShowVideoCardMenu", true);
             // });
+        },
+        drag(ev) {
+            ev.dataTransfer.setData(
+                "text",
+                `holodex.net/watch/${this.video.id}`
+            );
         },
     },
 };


### PR DESCRIPTION
You can drop a `youtube.com/watch/` , `youtu.be/` , `holodex.net/watch/` or `twitch.tv/` link on a multiview cell.
Dragging a video from the home or favorites pages will drag a `holodex.net/watch/` link.
Dropping the link on the iframe does not work.