### PR TITLE
Make music bar bigger when cursor enters draggable region

### DIFF
--- a/src/components/nav/MusicBar2.vue
+++ b/src/components/nav/MusicBar2.vue
@@ -215,6 +215,22 @@
 .music-more-btn {
 }
 
+.music-progress {
+    .v-slider {
+        cursor: pointer !important;
+    }
+
+    .v-slider__track-container {
+        transition: height 0.2s ease-out;
+    }
+
+    .v-slider:hover {
+        .v-slider__track-container {
+            height: 6px;
+        }
+    }
+}
+
 @keyframes shake {
     10%,
     90% {


### PR DESCRIPTION
![2021-07-02 at 21 37 34 - Cyan Swan](https://user-images.githubusercontent.com/431808/124281843-1dade100-db85-11eb-8ed7-4b9b4b83186a.gif)

It has been possible to move the music head by dragging the area near the thin music bar though, it is slightly difficult for users to find out that (it was me).
This PR makes the slider a bit more obviously draggable when a cursor enters the draggable area.
Also, change cursor style to `pointer` to indicate to users that it is clickable.