### PR TITLE
Channel/watch pages have search bar to include channel by default

### DIFF
--- a/src/components/common/SearchBar.vue
+++ b/src/components/common/SearchBar.vue
@@ -186,6 +186,30 @@ export default {
                 }
             },
         },
+        $route(to) {
+            // on non-channel pages, remove default channel query if it exists
+            if (this.query[0]?.$default && !to.path.startsWith("/channel/")) {
+                this.query.splice(0, 1);
+            }
+        },
+        "$store.state.channel.channel": function () {
+            // on channel pages, default the query to include channel
+            // console.log("$store.state.channel:", structuredClone(this.$store.state.channel), "query[0]:", this.query[0]);
+            if (this.query.length > 0 && !this.query[0].$default) return;
+            const { channel } = this.$store.state;
+            if (!channel?.channel || channel.isLoading || channel.hasError) return;
+            const defaultQuery = {
+                type: "channel",
+                value: channel.channel.id,
+                text: channel.channel.name,
+                $default: true,
+            };
+            if (this.query.length === 0) {
+                this.query.push(defaultQuery);
+            } else {
+                this.query.splice(0, 1, defaultQuery);
+            }
+        },
         // eslint-disable-next-line func-names
         search: debounce(function (val) {
             if (!val) return;

--- a/src/components/common/SearchBar.vue
+++ b/src/components/common/SearchBar.vue
@@ -186,6 +186,7 @@ export default {
                 }
             },
         },
+        // eslint-disable-next-line func-names
         "$route.name": function (name) {
             // when navigating away from channel/watch pages, $store.state.channel/watch aren't reset,
             // so need this $route hook to remove default channel query item if it exists
@@ -193,12 +194,14 @@ export default {
                 this.query = this.query.filter((item) => !item.isDefault);
             }
         },
+        // eslint-disable-next-line func-names
         "$store.state.channel.channel": function () {
             // on channel pages, default the query to include channel
             const { channel } = this.$store.state;
             if (!channel.channel || channel.isLoading || channel.hasError) return;
             this.addDefaultChannel(channel.channel);
         },
+        // eslint-disable-next-line func-names
         "$store.state.watch.video.channel": function () {
             // likewise on watch pages, default the query to include channel
             const { watch } = this.$store.state;

--- a/src/components/common/SearchBar.vue
+++ b/src/components/common/SearchBar.vue
@@ -187,7 +187,7 @@ export default {
             },
         },
         "$route.name": function (name) {
-            // when navigating away from channel/video pages, $store.state.channel/watch aren't reset,
+            // when navigating away from channel/watch pages, $store.state.channel/watch aren't reset,
             // so need this $route hook to remove default channel query item if it exists
             if (name !== "channel" && name !== "watch") {
                 this.query = this.query.filter((item) => !item.isDefault);
@@ -196,14 +196,12 @@ export default {
         "$store.state.channel.channel": function () {
             // on channel pages, default the query to include channel
             const { channel } = this.$store.state;
-            // console.log("$store.state.channel:", structuredClone(channel));
             if (!channel.channel || channel.isLoading || channel.hasError) return;
             this.addDefaultChannel(channel.channel);
         },
         "$store.state.watch.video.channel": function () {
             // likewise on watch pages, default the query to include channel
             const { watch } = this.$store.state;
-            // console.log("$store.state.watch:", structuredClone(watch));
             if (!watch.video.channel || watch.isLoading || watch.hasError) return;
             this.addDefaultChannel(watch.video.channel);
         },
@@ -308,11 +306,9 @@ export default {
             }
         },
         addItem(item) {
-            // console.log(item);
             this.query.push({ ...item });
         },
         addDefaultChannel(channel) {
-            // console.log("addDefaultChannel:", channel, "existing query:", this.query);
             const defaultQuery = {
                 type: "channel",
                 value: channel.id,

--- a/src/components/common/SearchBar.vue
+++ b/src/components/common/SearchBar.vue
@@ -186,29 +186,26 @@ export default {
                 }
             },
         },
-        $route(to) {
-            // on non-channel pages, remove default channel query if it exists
-            if (this.query[0]?.$default && !to.path.startsWith("/channel/")) {
-                this.query.splice(0, 1);
+        "$route.name": function (name) {
+            // when navigating away from channel/video pages, $store.state.channel/watch aren't reset,
+            // so need this $route hook to remove default channel query item if it exists
+            if (name !== "channel" && name !== "watch") {
+                this.query = this.query.filter((item) => !item.isDefault);
             }
         },
         "$store.state.channel.channel": function () {
             // on channel pages, default the query to include channel
-            // console.log("$store.state.channel:", structuredClone(this.$store.state.channel), "query[0]:", this.query[0]);
-            if (this.query.length > 0 && !this.query[0].$default) return;
             const { channel } = this.$store.state;
-            if (!channel?.channel || channel.isLoading || channel.hasError) return;
-            const defaultQuery = {
-                type: "channel",
-                value: channel.channel.id,
-                text: channel.channel.name,
-                $default: true,
-            };
-            if (this.query.length === 0) {
-                this.query.push(defaultQuery);
-            } else {
-                this.query.splice(0, 1, defaultQuery);
-            }
+            // console.log("$store.state.channel:", structuredClone(channel));
+            if (!channel.channel || channel.isLoading || channel.hasError) return;
+            this.addDefaultChannel(channel.channel);
+        },
+        "$store.state.watch.video.channel": function () {
+            // likewise on watch pages, default the query to include channel
+            const { watch } = this.$store.state;
+            // console.log("$store.state.watch:", structuredClone(watch));
+            if (!watch.video.channel || watch.isLoading || watch.hasError) return;
+            this.addDefaultChannel(watch.video.channel);
         },
         // eslint-disable-next-line func-names
         search: debounce(function (val) {
@@ -313,6 +310,22 @@ export default {
         addItem(item) {
             // console.log(item);
             this.query.push({ ...item });
+        },
+        addDefaultChannel(channel) {
+            // console.log("addDefaultChannel:", channel, "existing query:", this.query);
+            const defaultQuery = {
+                type: "channel",
+                value: channel.id,
+                text: channel.name,
+                isDefault: true,
+            };
+            if (this.query.length === 0) {
+                this.query.push(defaultQuery);
+            } else {
+                // replace any existing (assumed singular) default channel
+                const index = this.query.findIndex((item) => item.isDefault);
+                if (index >= 0) this.$set(this.query, index, defaultQuery);
+            }
         },
         onInput() {
             this.search = null;


### PR DESCRIPTION
When searching for only a channel (from the search bar), it goes to the channel page. However this removes the channel from the search bar, which is inconvenient when doing subsequent searches within a channel from that page.

It would also be convenient for watch pages to populate the channel in the search bar.

This PR addresses that by adding a "default" channel item to the search bar on channel/watch pages. This item is removed when going to a non-channel/watch/search page, or replaced if going to another channel/watch page.