### PR TITLE
[next] fix: Update dicebear API to 9.x

### DIFF
--- a/packages/react/src/components/header/userMenu/components/UserMenu.tsx
+++ b/packages/react/src/components/header/userMenu/components/UserMenu.tsx
@@ -56,7 +56,7 @@ export function UserMenu() {
     <DropdownMenu modal={false}>
       <DropdownMenuTrigger className="z-30 mx-2 w-8 shrink-0 overflow-hidden rounded-full bg-base-2">
         <img
-          src={`https://api.dicebear.com/7.x/shapes/svg?seed=${user.id}`}
+          src={`https://api.dicebear.com/9.x/shapes/svg?seed=${user.id}`}
           alt="User avatar"
         />
       </DropdownMenuTrigger>
@@ -64,7 +64,7 @@ export function UserMenu() {
         <DropdownMenuItem className="flex flex-row">
           <Avatar className="mx-2">
             <AvatarImage
-              src={`https://api.dicebear.com/7.x/shapes/svg?seed=${user.id}`}
+              src={`https://api.dicebear.com/9.x/shapes/svg?seed=${user.id}`}
               alt="userIcon"
             />
             <AvatarFallback>CN</AvatarFallback>

--- a/packages/react/src/routes/settings/user.tsx
+++ b/packages/react/src/routes/settings/user.tsx
@@ -38,7 +38,7 @@ export function SettingsUser() {
         <div className="flex flex-col items-center">
           <img
             className="h-24 w-24 rounded-full"
-            src={`https://api.dicebear.com/7.x/shapes/svg?seed=${user.id}`}
+            src={`https://api.dicebear.com/9.x/shapes/svg?seed=${user.id}`}
           />
           <Badge className="-mt-2">{user.role}</Badge>
         </div>


### PR DESCRIPTION
Dicebear API 7.x had an issue where mobile vs desktop could produce different outputs.
See dicebear/dicebear/issues/394 for details.

7.x URL remains in service for now, so it's not urgent to backport into v2, especially in the limited manner we currently use the avatars.