### PR TITLE
[next] maint: remove vue3 linting on PR

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -22,21 +22,6 @@ jobs:
     - run: npm test
       working-directory: packages/react
 
-  lint-vue3:
-    name: Lint Vue3 codebase
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v4
-    - name: Use Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '22.x'
-    - run: npm ci
-      working-directory: packages/vue3
-    - run: npm run lint
-      working-directory: packages/vue3
-
   lint:
     name: Lint codebase
     runs-on: ubuntu-latest


### PR DESCRIPTION
Since we are only planning to use the react version, the vue3 lint check is superfluous, it also erroneously fails on all incoming PRs to the `next` branch due to being untouched for a significant period of time.