### PR TITLE
[multiview] Add option under PresetSelector to specify whether Chat, TL, or both are opened by default for ChatCell

### DIFF
--- a/src/components/multiview/ChatCell.vue
+++ b/src/components/multiview/ChatCell.vue
@@ -124,16 +124,17 @@ export default {
             type: Number,
             default: 0,
         },
-        tl: {
-            type: Boolean,
+        mode: {
+            // 0: auto, 1: yt, 2: tl, 3: both
+            type: Number,
             required: false,
-            default: false,
+            default: 0,
         },
     },
     data() {
         return {
-            showTlChat: this.tl,
-            showYtChat: !this.tl,
+            showTlChat: this.mode === 3 || this.mode === 2 || (this.mode === 0 && this.$store.state.multiview.defaultShowTlChat),
+            showYtChat: this.mode === 3 || this.mode === 1 || (this.mode === 0 && this.$store.state.multiview.defaultShowYtChat),
             scale: 1,
         };
     },
@@ -215,10 +216,20 @@ export default {
         toggleYtChat() {
             this.showYtChat = !this.showYtChat;
             if (!this.showYtChat) this.showTlChat = true;
+            this.$store.commit("multiview/setLayoutContentWithKey", {
+                id: this.item.i,
+                key: "mode",
+                value: (this.showYtChat ? 1 : 0) + (this.showTlChat ? 2 : 0),
+            });
         },
         toggleTlChat() {
             this.showTlChat = !this.showTlChat;
             if (!this.showTlChat) this.showYtChat = true;
+            this.$store.commit("multiview/setLayoutContentWithKey", {
+                id: this.item.i,
+                key: "mode",
+                value: (this.showYtChat ? 1 : 0) + (this.showTlChat ? 2 : 0),
+            });
         },
         handleVideoUpdate(update) {
             const v = this.layoutContent[this.videoCellId].video;

--- a/src/components/multiview/EmptyCell.vue
+++ b/src/components/multiview/EmptyCell.vue
@@ -21,7 +21,7 @@
           color="teal darken-1"
           rounded-sm
           large
-          @click="setItemAsChat(item, false)"
+          @click="setItemAsChat(item, 1)"
         >
           <v-icon left>
             {{ icons.ytChat }}
@@ -33,7 +33,7 @@
           color="teal darken-1"
           rounded-sm
           large
-          @click="setItemAsChat(item, true)"
+          @click="setItemAsChat(item, 2)"
         >
           <v-icon left>
             {{ icons.tlChat }}
@@ -41,6 +41,22 @@
           TL
         </v-btn>
       </div>
+      <v-btn
+        class="mt-2"
+        color="teal darken-1"
+        rounded-sm
+        width="190px"
+        large
+        @click="setItemAsChat(item, 3)"
+      >
+        <v-icon left>
+          {{ icons.ytChat }}
+        </v-icon>
+        <v-icon left>
+          {{ icons.tlChat }}
+        </v-icon>
+        Chat + TL
+      </v-btn>
     </div>
     <CellControl :play-icon="icons.mdiPlay" class="mx-1 mb-2" @delete="deleteCell" />
   </div>
@@ -62,12 +78,12 @@ export default {
         };
     },
     methods: {
-        setItemAsChat(item, initAsTL) {
+        setItemAsChat(item, mode) {
             this.$store.commit("multiview/setLayoutContentById", {
                 id: item.i,
                 content: {
                     type: "chat",
-                    initAsTL,
+                    mode,
                 },
             });
         },

--- a/src/components/multiview/LayoutPreview.vue
+++ b/src/components/multiview/LayoutPreview.vue
@@ -23,6 +23,8 @@
 <script lang="ts">
 import { mapState } from 'vuex';
 
+const MIN_DOUBLE_ICON_HEIGHT = 8;
+const MIN_XSMALL_ICON_HEIGHT = 5;
 export default {
     name: "LayoutPreview",
     props: {
@@ -59,16 +61,16 @@ export default {
             return content && content[l.i] && content[l.i].type === "chat";
         },
         isXSmall(content, l) {
-            if (l.h < 7) {
-                return false;
+            if (l.h < MIN_DOUBLE_ICON_HEIGHT) {
+                return l.h < MIN_XSMALL_ICON_HEIGHT;
             }
             if (this.showBothIcons(content, l)) {
-                return l.h < 9;
+                return l.h < (MIN_XSMALL_ICON_HEIGHT * 2);
             }
             return false;
         },
         shouldShowEmoji(content, l) {
-            return l.h < 7 && this.showBothIcons(content, l);
+            return l.h < MIN_DOUBLE_ICON_HEIGHT && this.showBothIcons(content, l);
         },
         showBothIcons(content, l) {
             return content[l.i].mode === 3
@@ -77,12 +79,12 @@ export default {
         shouldShowYtIcon(content, l) {
             return content[l.i].mode === 1
                 || (content[l.i].mode === 0 && !this.defaultShowTlChat && this.defaultShowYtChat)
-                || (this.showBothIcons(content, l) && l.h >= 7);
+                || (this.showBothIcons(content, l) && l.h >= MIN_DOUBLE_ICON_HEIGHT);
         },
         shouldShowTlIcon(content, l) {
             return content[l.i].mode === 2
                 || (content[l.i].mode === 0 && this.defaultShowTlChat && !this.defaultShowYtChat)
-                || (this.showBothIcons(content, l) && l.h >= 7);
+                || (this.showBothIcons(content, l) && l.h >= MIN_DOUBLE_ICON_HEIGHT);
         },
         getStyle(l) {
             // viewport is constricted to 24 cols and 24 rows

--- a/src/components/multiview/LayoutPreview.vue
+++ b/src/components/multiview/LayoutPreview.vue
@@ -13,7 +13,7 @@
           <v-icon v-if="shouldShowYtIcon(content, l)" :small="!isXSmall(content, l)" :x-small="isXSmall(content, l)">
             {{ icons.ytChat }}
           </v-icon>
-          <span v-if="shouldShowEmoji(content, l)" class="text-caption">💬</span>
+          <span v-if="shouldShowEmoji(content, l)" class="text-caption" title="Chat+TL">💬</span>
         </template>
       </div>
     </template>

--- a/src/components/multiview/PresetSelector.vue
+++ b/src/components/multiview/PresetSelector.vue
@@ -123,7 +123,31 @@
         {{ $t("views.favorites.showall") }}
       </v-btn>
     </div>
-    <v-row class="ml-1">
+    <v-row class="ml-1 text-body-1 d-flex align-center">
+      <span class="pl-4 pr-2">Chat Defaults:</span>
+      <v-btn
+        :color="defaultShowYtChat ? 'primary' : ''"
+        small
+        @click.stop="toggleDefaultYtChat"
+      >
+        <v-icon small class="mr-1">
+          {{ icons.ytChat }}
+        </v-icon>
+        Chat
+      </v-btn>
+      <v-btn
+        class="ml-1"
+        :color="defaultShowTlChat ? 'primary' : ''"
+        small
+        @click.stop="toggleDefaultTlChat"
+      >
+        <v-icon small class="mr-1">
+          {{ icons.tlChat }}
+        </v-icon>
+        TL
+      </v-btn>
+    </v-row>
+    <v-row class="ml-1 mt-1">
       <template v-for="preset in currentGroup">
         <v-col :key="preset.name" cols="auto" class="justify-center pa-1">
           <LayoutPreviewCard
@@ -141,7 +165,7 @@
 <script lang="ts">
 import { mdiDotsVertical, mdiToggleSwitch } from "@mdi/js";
 import { decodeLayout } from "@/utils/mv-utils";
-import { mapState, mapGetters } from "vuex";
+import { mapState, mapGetters, mapMutations } from "vuex";
 import LayoutPreviewCard from "./LayoutPreviewCard.vue";
 
 export default {
@@ -164,7 +188,7 @@ export default {
         };
     },
     computed: {
-        ...mapState("multiview", ["presetLayout", "autoLayout", "activeVideos", "layout", "layoutContent"]),
+        ...mapState("multiview", ["presetLayout", "autoLayout", "activeVideos", "layout", "layoutContent", "defaultShowYtChat", "defaultShowTlChat"]),
         ...mapGetters("multiview", [
             "decodedCustomPresets",
             "decodedMobilePresets",
@@ -184,6 +208,7 @@ export default {
         },
     },
     methods: {
+        ...mapMutations("multiview", ["setDefaultYtChat", "setDefaultTlChat"]),
         setAutoLayout(index, encodedLayout) {
             this.$store.commit("multiview/setAutoLayout", { index, encodedLayout });
         },
@@ -198,6 +223,12 @@ export default {
         },
         presetInAuto(preset) {
             return this.autoLayoutSet.has(preset.id);
+        },
+        toggleDefaultYtChat() {
+            this.setDefaultYtChat(!this.defaultShowYtChat);
+        },
+        toggleDefaultTlChat() {
+            this.setDefaultTlChat(!this.defaultShowTlChat);
         },
     },
 };

--- a/src/store/multiview.module.ts
+++ b/src/store/multiview.module.ts
@@ -28,6 +28,8 @@ const persistedState = {
     twUrlHistory: [],
     // Default true for iOS device
     muteOthers: isAppleDevice,
+    defaultShowYtChat: true,
+    defaultShowTlChat: false,
     syncOffsets: {},
 };
 export const state = { ...initialState, ...persistedState };
@@ -233,6 +235,18 @@ const mutations = {
             }
         });
     }, 0, { trailing: true }),
+    setDefaultYtChat(state, value) {
+        state.defaultShowYtChat = value;
+        if (!value && !state.defaultShowTlChat) {
+            state.defaultShowTlChat = true;
+        }
+    },
+    setDefaultTlChat(state, value) {
+        state.defaultShowTlChat = value;
+        if (!value && !state.defaultShowYtChat) {
+            state.defaultShowYtChat = true;
+        }
+    },
     setVideoData(state, videos) {
         if (!videos) return;
         videos.forEach((video) => {

--- a/src/views/MultiView.vue
+++ b/src/views/MultiView.vue
@@ -100,7 +100,7 @@
             <ChatCell
               v-if="layoutContent[item.i] && layoutContent[item.i].type === 'chat'"
               :item="item"
-              :tl="layoutContent[item.i].initAsTL"
+              :mode="layoutContent[item.i].mode"
               :cell-width="columnWidth * item.w"
               @delete="handleDelete"
             />


### PR DESCRIPTION
Also:
Add Chat+TL button to EmptyCell
Persist Chat/TL mode per cell across refresh if they are ever manually toggled
Display Chat/TL mode on preset previews
<img width="533" alt="Screenshot 2025-05-07 at 8 15 40 PM" src="https://github.com/user-attachments/assets/aa045604-b906-4bd2-9f2a-a52724fbd99c" />
<img width="534" alt="Screenshot 2025-05-07 at 8 15 50 PM" src="https://github.com/user-attachments/assets/5e744a5a-fb32-46a2-bbaa-36c7c25abcf1" />
<img width="534" alt="Screenshot 2025-05-07 at 8 16 00 PM" src="https://github.com/user-attachments/assets/4c5b5841-ce68-429e-b07e-f8b17e054594" />

Tested pretty extensively:
* Chat/TL mode is represented by 'mode' param, with 0=defaults, 1=chat, 2=tl, 3=both
* As with chat cells, trying to turn off both buttons on the defaults options causes the other to reenable so that one is always enabled
* Selecting a preset layout causes all chat cells in that layout to match the defaults, as presets always omit mode (defaulting 0) for chat cells
* Refreshing the page causes all chat cells to update to the new default if they were left in 'mode 0'
* Setting Chat/TL on a chat cell moves it off of 'mode 0' to whichever it was manually set to, so refreshing the page after this will leave it in that state
* The Chat, TL, and Chat+TL buttons on empty cell create new ChatCells with mode 1, 2, and 3 respectively.
* LayoutPreview shows both icons where it can, shrinking them and then switching them out for the old emoji if shrinking wasn't enough. The old emoji gets a hover title (not a tooltip yet) showing "Chat+TL" on it.