### PR TITLE
Show Favorites streams that are live but scheduled far in the future

### DIFF
--- a/src/utils/backend-api.ts
+++ b/src/utils/backend-api.ts
@@ -171,7 +171,12 @@ export default {
               ),
           )
           // get currently live and upcoming lives within the next 3 weeks
-          .filter((live) => dayjs(live.start_scheduled).isBefore(dayjs().add(3, "w"))));
+          .filter(
+            (live) => (
+                live.start_actual
+                || dayjs(live.start_scheduled).isBefore(dayjs().add(3, "w"))
+              ),
+          ));
   },
   patchFavorites(jwt, operations) {
     return axiosInstance.patch("/users/favorites", operations, {


### PR DESCRIPTION
Follow up to this Discord message: https://discord.com/channels/796190073271353385/801759432450375700/1377529171940610048

For streams returned from the Favorites endpoint, if the stream is scheduled at least three weeks in advance, then it will be culled. However, it's possible for streams to go live before their scheduled time. Regardless, these streams end up being culled, which is not desirable.

To work around this, we can add a check for the `start_actual` timestamp. Or maybe it would be better to check for a `"live" status`? I'm not sure, but it fixes the specific stream in the Discord message.