### PR TITLE
fix: prevent live viewer update/malformed start_actual from breaking elapsedTime in WatchInfo/etc.

### DIFF
--- a/src/views/EditVideo.vue
+++ b/src/views/EditVideo.vue
@@ -321,7 +321,10 @@ export default {
             if (!update?.status || !update?.start_actual) return;
             this.video.live_viewers = update.live_viewers;
             this.video.status = update.status;
-            this.video.start_actual = update.start_actual;
+            // papers over an issue with socket sending a placeholder object in start_actual
+            if (typeof update.start_actual === "string") {
+                this.video.start_actual = update.start_actual;
+            }
         },
         async populateTopics() {
             this.topics = (await api.topics()).data.map((topic) => ({

--- a/src/views/Watch.vue
+++ b/src/views/Watch.vue
@@ -335,7 +335,10 @@ export default {
             if (!update?.status || !update?.start_actual) return;
             this.video.live_viewers = update.live_viewers;
             this.video.status = update.status;
-            this.video.start_actual = update.start_actual;
+            // papers over an issue with socket sending a placeholder object in start_actual
+            if (typeof update.start_actual === "string") {
+                this.video.start_actual = update.start_actual;
+            }
         },
         handleCurrentTime(time) {
             this.currentTime = time;


### PR DESCRIPTION
The websocket for video info updates is sometimes returning the following object in start_actual instead of a datetime string, so this prevents those from being bubbled down to the UI (and turning into NaN:NaN) when they show up.
<img width="1470" height="122" alt="image" src="https://github.com/user-attachments/assets/72552282-88cf-4c41-b240-5e02be9694e3" />
```
[
  "S38_wqRwD2E/en",
  {
    "type": "update",
    "live_viewers": 1347,
    "status": "live",
    "start_actual": [
      -1,
      {
        "_placeholder": true,
        "num": 0
      }
    ]
  }
]
```

This is just papering over the issue by preventing video.start_actual from being set to anything except strings, but works well enough; since video.start_actual is strictly for UI, enforcing that it's a string should be enough for now.

We want live_viewers to be updated even if start_actual has this placeholder object, so we don't include this check in the early return 3 lines above this, we just avoid setting start_actual to the invalid object.

Tested and verified that the NaN:NaN bug no longer occurs.