### PR TITLE
Better align highlight-bar to new YT embed seek bar

### DIFF
--- a/src/components/watch/WatchHighlights.vue
+++ b/src/components/watch/WatchHighlights.vue
@@ -229,7 +229,7 @@ export default {
         formatDuration,
         computeItemStyle(ts: number) {
             return {
-                marginLeft: `${Math.floor((ts / this.video.duration) * 1000) / 10}%`,
+                marginLeft: `${Math.floor((ts / this.video.duration) * 400) / 4}%`,
             };
         },
         computeTipStyle(bucket) {

--- a/src/components/watch/WatchHighlights.vue
+++ b/src/components/watch/WatchHighlights.vue
@@ -229,7 +229,7 @@ export default {
         formatDuration,
         computeItemStyle(ts: number) {
             return {
-                marginLeft: `${Math.round((ts / this.video.duration) * 100)}%`,
+                marginLeft: `${Math.floor((ts / this.video.duration) * 1000) / 10}%`,
             };
         },
         computeTipStyle(bucket) {
@@ -269,7 +269,7 @@ export default {
 </script>
 <style lang="scss">
 .highlight-container {
-  padding: 12px;
+  padding: 12px 36px;
   height: 30px;
   transition: all 0.2s ease-out;
 


### PR DESCRIPTION
YT seek bar uses 30px padding, plus the seek ball itself is 12px wide, so 36px from left edge to 0:00, same at the end
Also improve granularity of timestamp chips to ~~0.1%~~ 0.25% instead of 1%, and uses floor instead of round for consistency (going further to 0.01% didn't really improve the positioning any more).

Yes, it reduces the amount of space they have available, so the padding change might be fine to skip, but the granularity should definitely be fixed, as right now it causes far too many timestamps to step on each others' toes.

Screenshots (highlight chips moved to overlay the seek bar for comparison):
Previous - yellow chip being clicked + resulting seekbar location:
<img width="85" height="45" alt="Screenshot 2026-05-20 at 2 04 44 AM" src="https://github.com/user-attachments/assets/8dbd1ee4-6c40-4aed-910d-b395ac09dd77" />
Updated - center chip being clicked + resulting seekbar location:
<img width="81" height="38" alt="Screenshot 2026-05-20 at 2 03 55 AM" src="https://github.com/user-attachments/assets/160fa945-4253-430e-ac78-b1436317740d" />
Previous https://holodex.net/watch/DE7WL-YLk8Y:
<img width="961" height="153" alt="Screenshot 2026-05-20 at 2 08 15 AM" src="https://github.com/user-attachments/assets/86dc8476-9092-4baa-8274-f46415d714c0" />
Updated https://holodex.net/watch/DE7WL-YLk8Y:
<img width="961" height="178" alt="Screenshot 2026-05-20 at 2 07 55 AM" src="https://github.com/user-attachments/assets/16803ece-0fa7-477a-97cf-33f2d752d0f2" />

