### PR TITLE
add `Niko` theme

### DIFF
--- a/src/utils/themes.js
+++ b/src/utils/themes.js
@@ -370,5 +370,21 @@ export default [
       },
     },
   },
+  {
+    name: "Niko",
+    id: 23,
+    themes: {
+      dark: {
+        background: "#1f1c1f",
+        primary: "#f98d30",
+        secondary: "#ffdf82",
+      },
+      light: {
+        background: "#eddccc",
+        primary: "#322f2f",
+        secondary: "#d77834",
+      },
+    },
+  },
 
 ];


### PR DESCRIPTION
Add Nikotan theme to celebrate her return. ☺️🐅

Refs: https://hololive.hololivepro.com/wp-content/uploads/2023/09/Koganei-Niko_pr-img_01_a.png
<img width="800" height="1200" alt="Koganei-Niko_pr-img_01_a" src="https://github.com/user-attachments/assets/03503070-ad2a-4f90-a04f-08daf8d303ed" />
