### PR TITLE
Channel mentions & topic quick editor fixes & improvements

### DIFF
--- a/src/components/watch/WatchQuickEditor.vue
+++ b/src/components/watch/WatchQuickEditor.vue
@@ -107,8 +107,8 @@
         </template>
         <v-autocomplete
           v-model="selectedChannel"
-          :search-input.sync="search"
-          :items="searchResults"
+          :search-input.sync="inputChannel"
+          :items="searchChannels"
           no-filter
           hide-no-data
           hide-details
@@ -180,8 +180,8 @@ export default {
     data() {
         return {
             mentions: [],
-            search: "",
-            searchResults: [],
+            inputChannel: "",
+            searchChannels: [],
             selectedChannel: null,
 
             showSuccessAlert: false,
@@ -195,6 +195,7 @@ export default {
             topics: [],
             newTopic: null,
             currentTopic: null,
+
             isSelectedAll: false,
             isApplyingBulkEdit: false,
             deletionSet: new Set(),
@@ -207,18 +208,18 @@ export default {
     },
     watch: {
         // eslint-disable-next-line func-names
-        search: debounce(function () {
-            if (!this.search) {
-                this.searchResults = [];
+        inputChannel: debounce(function () {
+            if (!this.inputChannel) {
+                this.searchChannels = [];
                 return;
             }
             backendApi
                 .searchChannel({
                     type: CHANNEL_TYPES.VTUBER,
-                    queryText: this.search,
+                    queryText: this.inputChannel,
                 })
                 .then(({ data }) => {
-                    this.searchResults = data.filter(
+                    this.searchChannels = data.filter(
                         (d) => !(
                             this.video.channel.id === d.id
                             || this.mentions.find((m) => m.id === d.id)
@@ -226,12 +227,12 @@ export default {
                     );
                 });
         }, 400),
-        selectedChannel(val) {
-            if (val) {
-                this.search = "";
-                this.searchResults = [];
+        selectedChannel(channel) {
+            if (channel) {
+                this.inputChannel = "";
+                this.searchChannels = [];
                 this.selectedChannel = null;
-                this.addMention(val);
+                this.addMention(channel);
             }
         },
     },

--- a/src/components/watch/WatchQuickEditor.vue
+++ b/src/components/watch/WatchQuickEditor.vue
@@ -136,6 +136,7 @@
         }}</span>
         <span class="primary--text text-overline "> {{ currentTopic }} </span>
         <v-autocomplete
+          ref="topicAutocomplete"
           v-model="selectedTopic"
           :search-input.sync="inputTopic"
           :items="topics"
@@ -149,6 +150,7 @@
           :append-outer-icon="mdiContentSave"
           @click="loadTopics"
           @click:append-outer="saveTopic"
+          @keydown.enter="onTopicEnterKeyDown"
         />
       </v-col>
     </div>
@@ -189,7 +191,8 @@ export default {
             mdiContentSave,
 
             topics: [],
-            newTopic: null,
+            inputTopic: "",
+            selectedTopic: null,
             currentTopic: null,
 
             isSelectedAll: false,
@@ -381,6 +384,18 @@ export default {
         getTopicItemText(topic) {
             return `${topic.id} (${topic.count ?? 0})`;
         },
+        onTopicEnterKeyDown() {
+            // When dropdown menu is closed and enter key is pressed, save the topic.
+            // Also suppress v-autocomplete/v-select automatically activating the menu on enter key:
+            // There's no direct way to disable it and the menu activation is done after this handler is called,
+            // so the workaround is to force the menu closed in a $nextTick that's flushed before rendering.
+            const { topicAutocomplete } = this.$refs;
+            if (!topicAutocomplete.isMenuActive) {
+                this.$nextTick(() => {
+                    topicAutocomplete.isMenuActive = false;
+                });
+                this.saveTopic();
+            }
         },
         saveTopic() {
             const topicId = this.selectedTopic?.id || null;

--- a/src/components/watch/WatchQuickEditor.vue
+++ b/src/components/watch/WatchQuickEditor.vue
@@ -106,11 +106,10 @@
           </ChannelChip>
         </template>
         <v-autocomplete
-          v-model="fake"
+          v-model="selectedChannel"
           :search-input.sync="search"
           :items="searchResults"
           hide-no-data
-          multiple
           hide-details
           :rules="[]"
           return-object
@@ -119,22 +118,8 @@
           no-filter
           style="min-width: 300px"
         >
-          <template #selection="selection">
-            <ChannelChip
-              :key="selection.item.id + 'chip'"
-              :channel="selection.item"
-              :size="60"
-            >
-              <v-btn icon @click.stop.prevent="deleteMention(selection.item)">
-                <v-icon>{{ icons.mdiClose }}</v-icon>
-              </v-btn>
-            </ChannelChip>
-          </template>
           <template #item="dropdownItem">
-            <v-list-item-content
-              class="py-1 pt-1"
-              @click.stop="addMention(dropdownItem.item)"
-            >
+            <v-list-item-content class="py-1 pt-1">
               <v-list-item-subtitle class="text--primary">
                 {{ getChannelName(dropdownItem.item) }}
               </v-list-item-subtitle>
@@ -197,9 +182,8 @@ export default {
             mentions: [],
             search: "",
             searchResults: [],
-            fake: [],
+            selectedChannel: null,
 
-            hasError: false,
             showSuccessAlert: false,
             showErrorAlert: false,
             errorMessage: "",
@@ -242,10 +226,12 @@ export default {
                     );
                 });
         }, 400),
-        fake(nv: [any] | null) {
-            if (nv && nv.length && nv.length > 0) {
-                this.addMention(nv[0]);
-                this.fake = null;
+        selectedChannel(val) {
+            if (val) {
+                this.search = "";
+                this.searchResults = [];
+                this.selectedChannel = null;
+                this.addMention(val);
             }
         },
     },
@@ -264,14 +250,10 @@ export default {
             backendApi
                 .getMentions(this.video.id)
                 .then(({ data }) => {
-                    // this.isLoading = false;
                     this.mentions = data;
-                    this.searchResults = [];
-                    this.search = "";
                 })
                 .catch((e) => {
                     console.error(e);
-                    // this.hasError = true;
                 });
         },
         getChannelName(channel) {
@@ -354,7 +336,6 @@ export default {
                 });
         },
         addMention(channel) {
-            this.isLoading = true;
             backendApi
                 .addMention(this.video.id, channel.id, this.$store.state.userdata.jwt)
                 .then(({ data }) => {

--- a/src/components/watch/WatchQuickEditor.vue
+++ b/src/components/watch/WatchQuickEditor.vue
@@ -136,11 +136,15 @@
         }}</span>
         <span class="primary--text text-overline "> {{ currentTopic }} </span>
         <v-autocomplete
-          v-model="newTopic"
+          v-model="selectedTopic"
+          :search-input.sync="inputTopic"
           :items="topics"
-          :filter="topicFilter"
+          :filter="filterTopic"
           hide-details
           auto-select-first
+          return-object
+          item-value="id"
+          :item-text="getTopicItemText"
           label="Topic (leave empty to unset)"
           :append-outer-icon="mdiContentSave"
           @click="loadTopics"
@@ -225,6 +229,18 @@ export default {
                 this.searchChannels = [];
                 this.selectedChannel = null;
                 this.addMention(channel);
+            }
+        },
+        selectedTopic(topic) {
+            if (topic) {
+                // Update input value to be topic id rather than selected dropdown item text.
+                // This needs to be in a $nextTick in a watcher rather than in a @input/@change handler,
+                // because such handlers (even with $nextTick) fire too early.
+                // Also, not using the alternative solution of a #selection slot to display topic id for the input,
+                // since that results in e.g. backspace deleting the whole input instead of a single character.
+                this.$nextTick(() => {
+                    this.inputTopic = topic.id;
+                });
             }
         },
     },
@@ -360,22 +376,23 @@ export default {
         },
         async loadTopics() {
             if (this.topics.length > 0) return;
-            this.topics = (await backendApi.topics()).data.map((topic) => ({
-                value: topic.id,
-                text: `${topic.id} (${topic.count ?? 0})`,
-            }));
+            this.topics = (await backendApi.topics()).data;
+        },
+        getTopicItemText(topic) {
+            return `${topic.id} (${topic.count ?? 0})`;
+        },
         },
         saveTopic() {
+            const topicId = this.selectedTopic?.id || null;
             backendApi.topicSet(
-                this.newTopic,
+                topicId,
                 this.video.id,
                 this.$store.state.userdata.jwt,
             ).then(() => {
-                this.showSuccess(`Updated Topic to ${this.newTopic}`);
+                this.showSuccess(`Updated Topic to ${topicId}`);
             });
-            this.topic = this.newTopic;
         },
-        topicFilter(_, queryText, itemText) { // same as default filter, just also converting whitespace to underscore
+        filterTopic(_, queryText, itemText) { // same as default filter, just also converting whitespace to underscore
             return itemText.toString().replace(/\s+/g, "_").toLocaleLowerCase()
                 .indexOf(queryText.toString().replace(/\s+/g, "_").toLocaleLowerCase()) > -1;
         },

--- a/src/components/watch/WatchQuickEditor.vue
+++ b/src/components/watch/WatchQuickEditor.vue
@@ -109,23 +109,15 @@
           v-model="selectedChannel"
           :search-input.sync="inputChannel"
           :items="searchChannels"
-          no-filter
           hide-no-data
           hide-details
           auto-select-first
           return-object
           item-value="id"
+          :item-text="getChannelName"
           label="Add Mentioned Channels"
           style="min-width: 300px"
-        >
-          <template #item="dropdownItem">
-            <v-list-item-content class="py-1 pt-1">
-              <v-list-item-subtitle class="text--primary">
-                {{ getChannelName(dropdownItem.item) }}
-              </v-list-item-subtitle>
-            </v-list-item-content>
-          </template>
-        </v-autocomplete>
+        />
       </v-col>
       <v-divider vertical />
       <v-col v-if="video.type === 'stream' || video.type === 'placeholder'" cols="auto">

--- a/src/components/watch/WatchQuickEditor.vue
+++ b/src/components/watch/WatchQuickEditor.vue
@@ -109,13 +109,13 @@
           v-model="selectedChannel"
           :search-input.sync="search"
           :items="searchResults"
+          no-filter
           hide-no-data
           hide-details
-          :rules="[]"
+          auto-select-first
           return-object
           item-value="id"
           label="Add Mentioned Channels"
-          no-filter
           style="min-width: 300px"
         >
           <template #item="dropdownItem">
@@ -147,8 +147,8 @@
           v-model="newTopic"
           :items="topics"
           :filter="topicFilter"
-          inline
           hide-details
+          auto-select-first
           label="Topic (leave empty to unset)"
           :append-outer-icon="mdiContentSave"
           @click="loadTopics"


### PR DESCRIPTION
**Previously this PR only tries addressing race condition that can break adding multiple channel mentions in WatchQuickEditor, which the rest of this post elaborates on. Further improvements have since been added - see next post.**

If you're an editor, you can add channel mentions to videos. This is typically done via the WatchQuickEditor which appears in watch pages and video menus on favorites/channels/etc.

The code for adding channel mentions is a mess, resulting in potential race conditions and undefined behavior when the editor user adds channels quickly (or if the backend is just being slow). In particular, it can get into a state where it tries to add a previously added mention instead of the intended one, while erroneously showing the intended-to-add channel with a broken close button within the autocomplete input (instead of above it with the other channel mentions). Needless to say, for videos requiring lots of manual mentions, this is aggravating for editors.

This bug has multiple root causes:
1. Selecting the channel in the v-autocomplete dropdown (bound to searchResults) ultimately runs addMention twice: in the click handler and in the "fake" property watcher. The click handler is unnecessary.
2. The clearing of the bound "fake" property happens at a different time than the clearing of search/searchResults properties, the latter happening during async updateMentions that addMention calls. Together with (1), this is ripe conditions for, well, race conditions.
3. The clearing of the bound "fake" property (which is badly named and should really be the selected channel) by setting to null instead of empty array has undefined behavior since v-autocomplete has "multiple" flag, which in combination with above race conditions, seems to cause the #selection template (with its channel chip and close button) to persist indefinitely rather appear very briefly before the "fake" property is cleared ASAP.
4. There's also no point to the v-autocomplete having "multiple" flag and #selection template, both because the built-in nested selection chips aren't used to list the channel mentions (they're listed outside the v-autocomplete) and because the "fake" property is cleared ASAP anyway.

All the above are addressed, which should hopefully solve this issue.