### PR TITLE
Video card menu fixes (primarily for editors)

### DIFF
--- a/src/components/common/VideoCardMenu.vue
+++ b/src/components/common/VideoCardMenu.vue
@@ -138,12 +138,8 @@
       {{ $t("component.reportDialog.title") }}
     </v-list-item>
 
-    <template v-if="$store.getters['isSuperuser']">
-      <!-- <v-list-item> -->
-      <v-lazy>
-        <watch-quick-editor :video="video" />
-      </v-lazy>
-      <!-- </v-list-item> -->
+    <template v-if="hasEditor">
+      <watch-quick-editor :video="video" @ready="$emit('ready')" />
     </template>
   </v-list>
 </template>
@@ -202,6 +198,12 @@ export default {
             }
             return true;
         },
+        hasEditor() {
+            return this.$store.getters.isSuperuser;
+        },
+    },
+    mounted() {
+        if (!this.hasEditor) this.$emit("ready");
     },
     methods: {
         // Open google calendar to add the time specified in the element

--- a/src/components/common/VideoCardMenu.vue
+++ b/src/components/common/VideoCardMenu.vue
@@ -138,8 +138,8 @@
       {{ $t("component.reportDialog.title") }}
     </v-list-item>
 
-    <template v-if="hasEditor">
-      <watch-quick-editor :video="video" @ready="$emit('ready')" />
+    <template v-if="$store.getters['isSuperuser']">
+      <watch-quick-editor :video="video" />
     </template>
   </v-list>
 </template>
@@ -147,11 +147,12 @@
 <script>
 import { dayjs } from "@/utils/time";
 import copyToClipboard from "@/mixins/copyToClipboard";
+import WatchQuickEditor from "@/components/watch/WatchQuickEditor.vue";
 import VideoQuickPlaylist from "@/components/playlist/VideoQuickPlaylist.vue";
 
 export default {
     components: {
-        WatchQuickEditor: () => import("@/components/watch/WatchQuickEditor.vue"),
+        WatchQuickEditor,
         VideoQuickPlaylist,
     },
     mixins: [copyToClipboard],
@@ -198,12 +199,6 @@ export default {
             }
             return true;
         },
-        hasEditor() {
-            return this.$store.getters.isSuperuser;
-        },
-    },
-    mounted() {
-        if (!this.hasEditor) this.$emit("ready");
     },
     methods: {
         // Open google calendar to add the time specified in the element

--- a/src/components/video/VideoCard.vue
+++ b/src/components/video/VideoCard.vue
@@ -257,7 +257,6 @@
         nudge-top="20px"
         nudge-left="40px"
         content-class="video-card-menu-content"
-        transition="false"
       >
         <template #activator="{ on, attrs }">
           <v-btn
@@ -272,11 +271,7 @@
             <v-icon>{{ icons.mdiDotsVertical }}</v-icon>
           </v-btn>
         </template>
-        <video-card-menu
-          :video="data"
-          @closeMenu="showMenu = false"
-          @ready="menuReady = true"
-        />
+        <video-card-menu :video="data" @closeMenu="showMenu = false" />
       </v-menu>
     </a>
     <!-- optional breaker object to row-break into a new row. -->
@@ -424,7 +419,6 @@ export default {
             },
             placeholderOpen: false,
             showMenu: false,
-            menuReady: null,
         };
     },
     computed: {
@@ -610,16 +604,8 @@ export default {
                     // It also can't regain focus because it's hidden after menu opening, unless it's temporarily made visible again.
                     // Instead, it's easier to just focus the generated content div when the activator element loses focus.
                     this.$refs.videoMenu?.getActivator().addEventListener("blur", this.ensureVideoMenuFocusHandler);
-                    this.menuReady ||= false;
                 });
             }
-        },
-        menuReady(val) {
-            // Prevent a visible, mispositioned render by initially hiding it, then repositioning and showing it when it's ready.
-            const menu = this.$refs.videoMenu;
-            if (!menu) return;
-            if (val) menu.updateDimensions();
-            menu.$refs.content?.classList.toggle("video-card-menu-content-loading", !val);
         },
     },
     created() {
@@ -997,11 +983,5 @@ export default {
 /* prevent focus ring on menu */
 .video-card-menu-content:focus-visible {
   outline: none;
-}
-
-/* hide menu content until it's positioned to avoid visible misplacement */
-.video-card-menu-content-loading {
-  visibility: hidden !important;
-  pointer-events: none !important;
 }
 </style>

--- a/src/components/video/VideoCard.vue
+++ b/src/components/video/VideoCard.vue
@@ -604,7 +604,20 @@ export default {
                     // It also can't regain focus because it's hidden after menu opening, unless it's temporarily made visible again.
                     // Instead, it's easier to just focus the generated content div when the activator element loses focus.
                     const menu = this.$refs.videoMenu;
-                    menu?.getActivator().addEventListener("blur", this.ensureVideoMenuFocusHandler);
+                    if (!menu) return;
+                    menu.getActivator().addEventListener("blur", this.ensureVideoMenuFocusHandler);
+
+                    // Prevent a visible, mispositioned render by hiding it (via a class) until its contents are loaded and its
+                    // dimensions are (re)measurable, which is guaranteed by the time the menu open transition ends.
+                    const { content } = menu.$refs;
+                    if (content) {
+                        content.classList.add("video-card-menu-content-loading");
+                        content.addEventListener("transitionend", (e) => {
+                            if (e.currentTarget !== content) return; // shouldn't be any nested transitions, but just in case
+                            menu.updateDimensions();
+                            content.classList.remove("video-card-menu-content-loading");
+                        }, { once: true });
+                    }
                 });
             }
         },
@@ -984,5 +997,11 @@ export default {
 /* prevent focus ring on menu */
 .video-card-menu-content:focus-visible {
   outline: none;
+}
+
+/* hide menu content until it's positioned to avoid visible misplacement */
+.video-card-menu-content-loading {
+  visibility: hidden !important;
+  pointer-events: none !important;
 }
 </style>

--- a/src/components/video/VideoCard.vue
+++ b/src/components/video/VideoCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <a
+  <div
     class="video-card no-decoration d-flex"
     :class="{
       'video-card-fluid': fluid,
@@ -9,17 +9,16 @@
       'video-card-multiview-active': inMultiViewActiveVideos,
       'flex-column': !horizontal && !denseList,
     }"
-    :target="redirectMode ? '_blank' : ''"
-    :href="href"
-    rel="noopener"
     draggable="true"
     style="position: relative"
-    @click.exact="onThumbnailClicked"
     @dragstart="drag"
   >
     <!-- Video Image with Duration -->
-    <div
+    <a
       v-if="!denseList"
+      :target="redirectMode ? '_blank' : ''"
+      :href="href"
+      rel="noopener"
       style="position: relative; width: 100%"
       class="video-thumbnail white--text rounded flex-shrink-0 d-flex"
       :style="
@@ -27,6 +26,7 @@
           !shouldHideThumbnail &&
           `background: url(${imageSrc}) center/cover;`
       "
+      @click.exact="onThumbnailClicked"
     >
       <PlaceholderOverlay
         v-if="shouldShowPlaceholderOverlay"
@@ -135,7 +135,7 @@
         width="100%"
         :aspect-ratio="60 / 9"
       />
-    </div>
+    </a>
     <a
       class="d-flex flex-row flex-grow-1 no-decoration video-card-text"
       :href="watchLink"
@@ -281,17 +281,23 @@
     >
       <template v-if="activePlaylistItem">
         <button @click.stop.prevent="move(data.id, 'up')">
-          <v-icon small> {{ icons.mdiChevronUp }} </v-icon>
+          <v-icon small>
+            {{ icons.mdiChevronUp }}
+          </v-icon>
         </button>
         <button
           @click.stop.prevent="
             $store.commit('playlist/removeVideoByID', data.id)
           "
         >
-          <v-icon small> {{ icons.mdiDelete }} </v-icon>
+          <v-icon small>
+            {{ icons.mdiDelete }}
+          </v-icon>
         </button>
         <button @click.stop.prevent="move(data.id, 'down')">
-          <v-icon small> {{ icons.mdiChevronDown }} </v-icon>
+          <v-icon small>
+            {{ icons.mdiChevronDown }}
+          </v-icon>
         </button>
       </template>
       <slot name="action" />
@@ -303,7 +309,7 @@
       v-model="placeholderOpen"
       :video="data"
     />
-  </a>
+  </div>
 </template>
 
 <script lang="ts">

--- a/src/components/video/VideoCard.vue
+++ b/src/components/video/VideoCard.vue
@@ -249,12 +249,14 @@
       </div>
       <!-- Vertical dots menu -->
       <v-menu
+        ref="videoMenu"
         v-model="showMenu"
         bottom
         left
         :close-on-content-click="false"
         nudge-top="20px"
         nudge-left="40px"
+        content-class="video-card-menu-content"
       >
         <template #activator="{ on, attrs }">
           <v-btn
@@ -586,6 +588,21 @@ export default {
     // created() {
     //     this.data = this.video || this.source;
     // },
+    watch: {
+        showMenu(val) {
+            if (val) {
+                this.$nextTick(() => {
+                    // Menu keyboard navigation works as long as either the activator element or the generated content div has focus.
+                    // The activator element is initially be focused when the menu opens, but it loses its focus when
+                    // menu items or another video card are hovered, page is scrolled, page loses focus, and possibly other cases.
+                    // It also can't regain focus because it's hidden after menu opening, unless it's temporarily made visible again.
+                    // Instead, it's easier to just focus the generated content div when the activator element loses focus.
+                    const menu = this.$refs.videoMenu;
+                    menu?.getActivator().addEventListener("blur", this.ensureVideoMenuFocusHandler);
+                });
+            }
+        },
+    },
     created() {
         this.$store.getters["history/hasWatched"](this.data.id)
             .then((x) => {
@@ -614,6 +631,7 @@ export default {
             clearInterval(this.updatecycle);
             this.updatecycle = null;
         }
+        this.$refs.videoMenu?.getActivator()?.removeEventListener("blur", this.ensureVideoMenuFocusHandler);
     },
     methods: {
         formatDuration,
@@ -702,6 +720,13 @@ export default {
                 throw new Error("can't move stuff to beyond the end");
             }
             this.$store.commit("playlist/reorder", { from: curIdx, to: toIdx });
+        },
+        ensureVideoMenuFocusHandler() {
+            // note: this is its own method so that multiple addEventListener(..., this handler) is idempotent
+            const menuContent = this.$refs.videoMenu?.$refs.content;
+            if (!menuContent) return;
+            if (menuContent.tabIndex === -1) menuContent.tabIndex = 0; // ensure its focusable
+            menuContent.focus({ preventScroll: true });
         },
     },
 };
@@ -948,5 +973,10 @@ export default {
 }
 .plain-button:hover:before {
   background-color: transparent;
+}
+
+/* prevent focus ring on menu */
+.video-card-menu-content:focus-visible {
+  outline: none;
 }
 </style>

--- a/src/components/video/VideoCard.vue
+++ b/src/components/video/VideoCard.vue
@@ -257,6 +257,7 @@
         nudge-top="20px"
         nudge-left="40px"
         content-class="video-card-menu-content"
+        transition="false"
       >
         <template #activator="{ on, attrs }">
           <v-btn
@@ -271,7 +272,11 @@
             <v-icon>{{ icons.mdiDotsVertical }}</v-icon>
           </v-btn>
         </template>
-        <video-card-menu :video="data" @closeMenu="showMenu = false" />
+        <video-card-menu
+          :video="data"
+          @closeMenu="showMenu = false"
+          @ready="menuReady = true"
+        />
       </v-menu>
     </a>
     <!-- optional breaker object to row-break into a new row. -->
@@ -419,6 +424,7 @@ export default {
             },
             placeholderOpen: false,
             showMenu: false,
+            menuReady: null,
         };
     },
     computed: {
@@ -603,23 +609,17 @@ export default {
                     // menu items or another video card are hovered, page is scrolled, page loses focus, and possibly other cases.
                     // It also can't regain focus because it's hidden after menu opening, unless it's temporarily made visible again.
                     // Instead, it's easier to just focus the generated content div when the activator element loses focus.
-                    const menu = this.$refs.videoMenu;
-                    if (!menu) return;
-                    menu.getActivator().addEventListener("blur", this.ensureVideoMenuFocusHandler);
-
-                    // Prevent a visible, mispositioned render by hiding it (via a class) until its contents are loaded and its
-                    // dimensions are (re)measurable, which is guaranteed by the time the menu open transition ends.
-                    const { content } = menu.$refs;
-                    if (content) {
-                        content.classList.add("video-card-menu-content-loading");
-                        content.addEventListener("transitionend", (e) => {
-                            if (e.currentTarget !== content) return; // shouldn't be any nested transitions, but just in case
-                            menu.updateDimensions();
-                            content.classList.remove("video-card-menu-content-loading");
-                        }, { once: true });
-                    }
+                    this.$refs.videoMenu?.getActivator().addEventListener("blur", this.ensureVideoMenuFocusHandler);
+                    this.menuReady ||= false;
                 });
             }
+        },
+        menuReady(val) {
+            // Prevent a visible, mispositioned render by initially hiding it, then repositioning and showing it when it's ready.
+            const menu = this.$refs.videoMenu;
+            if (!menu) return;
+            if (val) menu.updateDimensions();
+            menu.$refs.content?.classList.toggle("video-card-menu-content-loading", !val);
         },
     },
     created() {

--- a/src/components/watch/WatchQuickEditor.vue
+++ b/src/components/watch/WatchQuickEditor.vue
@@ -27,7 +27,7 @@
               v-bind="attrs"
               rounded
               left
-              size="40"
+              size="60"
               v-on="on"
             >
               <v-btn icon @click.stop.prevent="applyDeleteMentions()">
@@ -55,7 +55,7 @@
               v-bind="attrs"
               rounded
               left
-              size="40"
+              size="60"
               v-on="on"
             >
               <v-btn icon @click.stop.prevent="toggleMentionSelection()">
@@ -72,7 +72,7 @@
           <span v-else>Select All</span>
         </v-tooltip>
 
-        <!-- <v-avatar rounded left size="40">
+        <!-- <v-avatar rounded left size="60">
           <v-icon size="25" color="grey darken-2">
             {{ mdiAt }}
           </v-icon>
@@ -145,12 +145,12 @@
       </v-col>
       <v-divider vertical />
       <v-col v-if="video.type === 'stream' || video.type === 'placeholder'" cols="auto">
-        <!-- <v-avatar rounded left size="40">
+        <!-- <v-avatar rounded left size="60">
           <v-icon size="25" color="grey darken-2">
             {{ icons.mdiPencil }}
           </v-icon>
         </v-avatar> -->
-        <v-avatar rounded left size="40">
+        <v-avatar rounded left size="60">
           <v-icon size="25" color="grey darken-2">
             {{ icons.mdiAnimationPlay }}
           </v-icon>

--- a/src/components/watch/WatchQuickEditor.vue
+++ b/src/components/watch/WatchQuickEditor.vue
@@ -258,17 +258,12 @@ export default {
     beforeDestroy() {},
     methods: {
         updateCurrentTopic() {
-            return backendApi
-                .getVideoTopic(this.video.id)
-                .then(({ data }) => {
-                    this.currentTopic = data.topic_id;
-                })
-                .catch((e) => {
-                    console.error(e);
-                });
+            backendApi.getVideoTopic(this.video.id).then(({ data }) => {
+                this.currentTopic = data.topic_id;
+            });
         },
         updateMentions() {
-            return backendApi
+            backendApi
                 .getMentions(this.video.id)
                 .then(({ data }) => {
                     // this.isLoading = false;

--- a/src/components/watch/WatchQuickEditor.vue
+++ b/src/components/watch/WatchQuickEditor.vue
@@ -27,7 +27,7 @@
               v-bind="attrs"
               rounded
               left
-              size="60"
+              size="40"
               v-on="on"
             >
               <v-btn icon @click.stop.prevent="applyDeleteMentions()">
@@ -55,7 +55,7 @@
               v-bind="attrs"
               rounded
               left
-              size="60"
+              size="40"
               v-on="on"
             >
               <v-btn icon @click.stop.prevent="toggleMentionSelection()">
@@ -72,7 +72,7 @@
           <span v-else>Select All</span>
         </v-tooltip>
 
-        <!-- <v-avatar rounded left size="60">
+        <!-- <v-avatar rounded left size="40">
           <v-icon size="25" color="grey darken-2">
             {{ mdiAt }}
           </v-icon>
@@ -145,12 +145,12 @@
       </v-col>
       <v-divider vertical />
       <v-col v-if="video.type === 'stream' || video.type === 'placeholder'" cols="auto">
-        <!-- <v-avatar rounded left size="60">
+        <!-- <v-avatar rounded left size="40">
           <v-icon size="25" color="grey darken-2">
             {{ icons.mdiPencil }}
           </v-icon>
         </v-avatar> -->
-        <v-avatar rounded left size="60">
+        <v-avatar rounded left size="40">
           <v-icon size="25" color="grey darken-2">
             {{ icons.mdiAnimationPlay }}
           </v-icon>

--- a/src/components/watch/WatchQuickEditor.vue
+++ b/src/components/watch/WatchQuickEditor.vue
@@ -252,14 +252,8 @@ export default {
         },
     },
     mounted() {
-        Promise.allSettled([
-            this.updateCurrentTopic(),
-            this.updateMentions(),
-        ]).then(() => {
-            this.$nextTick(() => {
-                this.$emit("ready");
-            });
-        });
+        this.updateMentions();
+        this.updateCurrentTopic();
     },
     beforeDestroy() {},
     methods: {

--- a/src/components/watch/WatchQuickEditor.vue
+++ b/src/components/watch/WatchQuickEditor.vue
@@ -252,18 +252,29 @@ export default {
         },
     },
     mounted() {
-        this.updateMentions();
-        this.updateCurrentTopic();
+        Promise.allSettled([
+            this.updateCurrentTopic(),
+            this.updateMentions(),
+        ]).then(() => {
+            this.$nextTick(() => {
+                this.$emit("ready");
+            });
+        });
     },
     beforeDestroy() {},
     methods: {
         updateCurrentTopic() {
-            backendApi.getVideoTopic(this.video.id).then(({ data }) => {
-                this.currentTopic = data.topic_id;
-            });
+            return backendApi
+                .getVideoTopic(this.video.id)
+                .then(({ data }) => {
+                    this.currentTopic = data.topic_id;
+                })
+                .catch((e) => {
+                    console.error(e);
+                });
         },
         updateMentions() {
-            backendApi
+            return backendApi
                 .getMentions(this.video.id)
                 .then(({ data }) => {
                     // this.isLoading = false;

--- a/src/components/watch/WatchQuickEditor.vue
+++ b/src/components/watch/WatchQuickEditor.vue
@@ -118,6 +118,7 @@
           label="Add Mentioned Channels"
           no-filter
           style="min-width: 300px"
+          @keydown.stop
         >
           <template #selection="selection">
             <ChannelChip
@@ -168,6 +169,7 @@
           :append-outer-icon="mdiContentSave"
           @click="loadTopics"
           @click:append-outer="saveTopic"
+          @keydown.stop
         />
       </v-col>
     </div>

--- a/src/views/channel_views/ChannelVideos.vue
+++ b/src/views/channel_views/ChannelVideos.vue
@@ -14,7 +14,7 @@
       dense
     />
     <!-- Render skeleton items when data hasn't loaded yet -->
-    <SkeletonCardList v-if="isLoading" :cols="cols" dense />
+    <SkeletonCardList v-if="isLoading" :cols="colSizes" dense />
   </generic-list-loader>
 </template>
 


### PR DESCRIPTION
1. Fix simultaneous arrow key navigation on video card menu and the nested channel mentions and topic dropdowns for editors. Practically this allows just using the keyboard to add channel mentions or select topic in that menu.
2. Fix video card menu keyboard navigation breaking when menu items or another video card are hovered, page is scrolled, page loses focus, and possibly other cases.
3. Fix for the first opening of the video card menu sometimes being mispositioned for editors (subsequent openings try to put menu to left of button yet still within viewport). This still doesn't fully fix the menu for videos that already have enough channel mentions (which are asynchronously loaded in) to affect the menu size, but it's good enough.
4. ~~Change height of channel mention and topic buttons to be the same as the channel icons themselves, such that videos with 0 mentions have the same height as those with at most a single row's worth of mentions, and channel mention and topic inputs remain horizontally aligned. This helps with (3).~~ edit: removed since conflicts with another PR that does it better
5.  Fix error on channels page that resulted in video cards briefly having wrong dimensions during loading

There are some other changes that don't really change functionality - they're artifacts of the git precommit linter or leftover from previous fix attempts that made sense to keep (like moving tags/attrs around to avoid nested `<a>` elements).